### PR TITLE
Keep background chat streams alive when switching chats

### DIFF
--- a/src/renderer/src/__tests__/chat-transport.test.tsx
+++ b/src/renderer/src/__tests__/chat-transport.test.tsx
@@ -55,7 +55,7 @@ describe('IpcChatTransport', () => {
         expect(streaming.abortMessage).not.toHaveBeenCalled();
     });
 
-    it('removes listeners and aborts when send stream is canceled', async () => {
+    it('removes listeners without aborting when send stream is canceled', async () => {
         const streaming = createStreamingApiMock();
         setWindowApi(streaming);
 
@@ -80,7 +80,7 @@ describe('IpcChatTransport', () => {
         await stream.getReader().cancel();
 
         expect(streaming.removeListeners).toHaveBeenCalledWith('chat-stream-chat-2');
-        expect(streaming.abortMessage).toHaveBeenCalledWith({ streamChannel: 'chat-stream-chat-2' });
+        expect(streaming.abortMessage).not.toHaveBeenCalled();
     });
 
     it('surfaces sendMessage failures and cleans listeners', async () => {
@@ -104,6 +104,28 @@ describe('IpcChatTransport', () => {
         expect(streaming.removeListeners).toHaveBeenCalledWith('chat-stream-chat-3');
     });
 
+
+
+    it('aborts streaming when the abort signal fires', async () => {
+        const streaming = createStreamingApiMock();
+        setWindowApi(streaming);
+
+        const transport = new IpcChatTransport();
+        const controller = new AbortController();
+        await transport.sendMessages({
+            trigger: 'submit-message',
+            chatId: 'chat-5',
+            messageId: undefined,
+            messages: [] as UIMessage[],
+            abortSignal: controller.signal,
+            metadata: { modelId: 'openai:gpt-4o' },
+        });
+
+        controller.abort();
+
+        expect(streaming.abortMessage).toHaveBeenCalledWith({ streamChannel: 'chat-stream-chat-5' });
+        expect(streaming.removeListeners).toHaveBeenCalledWith('chat-stream-chat-5');
+    });
     it('fails early when model metadata is missing', async () => {
         const streaming = createStreamingApiMock();
         const chat = createChatApiMock();

--- a/src/renderer/src/chat-transport.ts
+++ b/src/renderer/src/chat-transport.ts
@@ -138,8 +138,9 @@ export class IpcChatTransport implements ChatTransport<UIMessage> {
                 }
             },
             cancel() {
+                // Preserve in-flight generation when the UI disconnects (e.g. switching chats).
+                // Explicit user cancellation is handled via the abort signal path above.
                 cleanup();
-                window.api.streaming.abortMessage({ streamChannel });
             },
         });
         return Promise.resolve(stream);


### PR DESCRIPTION
### Motivation

- Switching the active chat in the UI was canceling the stream reader and forwarding that as a backend abort, which stopped in-flight generations for chats that were no longer selected.

### Description

- Changed the Electron IPC chat transport so reader cancellation only removes listeners and does not call the backend abort path, allowing background generations to continue (`src/renderer/src/chat-transport.ts`).
- Preserved explicit user cancellation by keeping the `abortSignal` flow that calls `window.api.streaming.abortMessage` when a user-triggered abort occurs (`src/renderer/src/chat-transport.ts`).
- Updated and added transport tests to reflect the new behavior and to verify abort semantics (`src/renderer/src/__tests__/chat-transport.test.tsx`).

### Testing

- Ran the updated unit tests with `cd src/renderer && npm run test -- src/__tests__/chat-transport.test.tsx`, and the suite passed (`5 passed`).
- Existing transport failure and validation tests were kept and continue to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff0f528e74832293ece2e5f39b3333)