### PR TITLE
Add Workflows: DB migrations, Drizzle schema, repositories, services, and tests

### DIFF
--- a/migrations/0033_special_emma_frost.sql
+++ b/migrations/0033_special_emma_frost.sql
@@ -1,0 +1,48 @@
+CREATE TYPE "public"."workflow_run_event_type" AS ENUM('created', 'started', 'progress', 'completed', 'failed', 'cancelled');--> statement-breakpoint
+CREATE TYPE "public"."workflow_run_status" AS ENUM('queued', 'running', 'completed', 'failed', 'cancelled');--> statement-breakpoint
+CREATE TYPE "public"."workflow_status" AS ENUM('active', 'archived');--> statement-breakpoint
+CREATE TABLE "Workflow" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"title" text NOT NULL,
+	"summary" text,
+	"status" "workflow_status" DEFAULT 'active' NOT NULL,
+	"latestVersion" integer DEFAULT 1 NOT NULL,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	"updatedAt" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "WorkflowRun" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"workflowId" uuid NOT NULL,
+	"workflowVersionId" uuid NOT NULL,
+	"status" "workflow_run_status" DEFAULT 'queued' NOT NULL,
+	"startedAt" timestamp,
+	"completedAt" timestamp,
+	"errorMessage" text,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	"updatedAt" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "WorkflowRunEvent" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"workflowRunId" uuid NOT NULL,
+	"eventType" "workflow_run_event_type" NOT NULL,
+	"status" "workflow_run_status",
+	"message" text,
+	"payload" jsonb,
+	"createdAt" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "WorkflowVersion" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"workflowId" uuid NOT NULL,
+	"version" integer NOT NULL,
+	"graph" jsonb NOT NULL,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	"updatedAt" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "WorkflowRun" ADD CONSTRAINT "WorkflowRun_workflowId_Workflow_id_fk" FOREIGN KEY ("workflowId") REFERENCES "public"."Workflow"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "WorkflowRun" ADD CONSTRAINT "WorkflowRun_workflowVersionId_WorkflowVersion_id_fk" FOREIGN KEY ("workflowVersionId") REFERENCES "public"."WorkflowVersion"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "WorkflowRunEvent" ADD CONSTRAINT "WorkflowRunEvent_workflowRunId_WorkflowRun_id_fk" FOREIGN KEY ("workflowRunId") REFERENCES "public"."WorkflowRun"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "WorkflowVersion" ADD CONSTRAINT "WorkflowVersion_workflowId_Workflow_id_fk" FOREIGN KEY ("workflowId") REFERENCES "public"."Workflow"("id") ON DELETE cascade ON UPDATE no action;

--- a/migrations/0034_yummy_robin_chapel.sql
+++ b/migrations/0034_yummy_robin_chapel.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX "workflow_version_workflow_id_version_idx" ON "WorkflowVersion" USING btree ("workflowId","version");

--- a/migrations/meta/0033_snapshot.json
+++ b/migrations/meta/0033_snapshot.json
@@ -1,0 +1,1000 @@
+{
+  "id": "757c9237-d73e-40a3-9a2f-933278da8502",
+  "prevId": "2b6ca64b-748a-4a67-ad22-11849d714c1b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.Chat": {
+      "name": "Chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "pinnedAt": {
+          "name": "pinnedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selectedProvider": {
+          "name": "selectedProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selectedModelId": {
+          "name": "selectedModelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selectedPersonaId": {
+          "name": "selectedPersonaId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected": {
+          "name": "selected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "lastMessage": {
+          "name": "lastMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastMessageAt": {
+          "name": "lastMessageAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Message": {
+      "name": "Message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "message_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modelIdentifier": {
+          "name": "modelIdentifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_chatId_Chat_id_fk": {
+          "name": "Message_chatId_Chat_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Model": {
+      "name": "Model",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modelId": {
+          "name": "modelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "attachment": {
+          "name": "attachment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "toolCall": {
+          "name": "toolCall",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "model_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'not_defined'"
+        },
+        "input_modalities": {
+          "name": "input_modalities",
+          "type": "model_modality[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "output_modalities": {
+          "name": "output_modalities",
+          "type": "model_modality[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "releaseDate": {
+          "name": "releaseDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastUpdatedByProvider": {
+          "name": "lastUpdatedByProvider",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contextWindow": {
+          "name": "contextWindow",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 128000
+        },
+        "maxOutputWindow": {
+          "name": "maxOutputWindow",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 4096
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Model_providerId_ModelProvider_id_fk": {
+          "name": "Model_providerId_ModelProvider_id_fk",
+          "tableFrom": "Model",
+          "tableTo": "ModelProvider",
+          "columnsFrom": [
+            "providerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ModelProvider": {
+      "name": "ModelProvider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "apiKey": {
+          "name": "apiKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "apiUrl": {
+          "name": "apiUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ModelProvider_name_unique": {
+          "name": "ModelProvider_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Persona": {
+      "name": "Persona",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "Persona_name_unique": {
+          "name": "Persona_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Command": {
+      "name": "Command",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "argumentLabel": {
+          "name": "argumentLabel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "Command_name_unique": {
+          "name": "Command_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.McpServer": {
+      "name": "McpServer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transport_type": {
+          "name": "transport_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "tool_approvals": {
+          "name": "tool_approvals",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "McpServer_name_unique": {
+          "name": "McpServer_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WebSearchConfig": {
+      "name": "WebSearchConfig",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "apiKey": {
+          "name": "apiKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "WebSearchConfig_type_unique": {
+          "name": "WebSearchConfig_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Workflow": {
+      "name": "Workflow",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "workflow_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "latestVersion": {
+          "name": "latestVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowRun": {
+      "name": "WorkflowRun",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowVersionId": {
+          "name": "workflowVersionId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflow_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "WorkflowRun_workflowId_Workflow_id_fk": {
+          "name": "WorkflowRun_workflowId_Workflow_id_fk",
+          "tableFrom": "WorkflowRun",
+          "tableTo": "Workflow",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "WorkflowRun_workflowVersionId_WorkflowVersion_id_fk": {
+          "name": "WorkflowRun_workflowVersionId_WorkflowVersion_id_fk",
+          "tableFrom": "WorkflowRun",
+          "tableTo": "WorkflowVersion",
+          "columnsFrom": [
+            "workflowVersionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowRunEvent": {
+      "name": "WorkflowRunEvent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workflowRunId": {
+          "name": "workflowRunId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "workflow_run_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflow_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "WorkflowRunEvent_workflowRunId_WorkflowRun_id_fk": {
+          "name": "WorkflowRunEvent_workflowRunId_WorkflowRun_id_fk",
+          "tableFrom": "WorkflowRunEvent",
+          "tableTo": "WorkflowRun",
+          "columnsFrom": [
+            "workflowRunId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowVersion": {
+      "name": "WorkflowVersion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "WorkflowVersion_workflowId_Workflow_id_fk": {
+          "name": "WorkflowVersion_workflowId_Workflow_id_fk",
+          "tableFrom": "WorkflowVersion",
+          "tableTo": "Workflow",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.message_role": {
+      "name": "message_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "assistant",
+        "system"
+      ]
+    },
+    "public.model_modality": {
+      "name": "model_modality",
+      "schema": "public",
+      "values": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ]
+    },
+    "public.model_status": {
+      "name": "model_status",
+      "schema": "public",
+      "values": [
+        "not_defined",
+        "deprecated"
+      ]
+    },
+    "public.workflow_run_event_type": {
+      "name": "workflow_run_event_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "started",
+        "progress",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.workflow_run_status": {
+      "name": "workflow_run_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.workflow_status": {
+      "name": "workflow_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "archived"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/0034_snapshot.json
+++ b/migrations/meta/0034_snapshot.json
@@ -1,0 +1,1022 @@
+{
+  "id": "139ec962-d80f-496d-9118-1c2c5fa94a68",
+  "prevId": "757c9237-d73e-40a3-9a2f-933278da8502",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.Chat": {
+      "name": "Chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "pinnedAt": {
+          "name": "pinnedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selectedProvider": {
+          "name": "selectedProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selectedModelId": {
+          "name": "selectedModelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selectedPersonaId": {
+          "name": "selectedPersonaId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected": {
+          "name": "selected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "lastMessage": {
+          "name": "lastMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastMessageAt": {
+          "name": "lastMessageAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Message": {
+      "name": "Message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "message_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modelIdentifier": {
+          "name": "modelIdentifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_chatId_Chat_id_fk": {
+          "name": "Message_chatId_Chat_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Model": {
+      "name": "Model",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modelId": {
+          "name": "modelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "attachment": {
+          "name": "attachment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "toolCall": {
+          "name": "toolCall",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "model_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'not_defined'"
+        },
+        "input_modalities": {
+          "name": "input_modalities",
+          "type": "model_modality[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "output_modalities": {
+          "name": "output_modalities",
+          "type": "model_modality[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "releaseDate": {
+          "name": "releaseDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastUpdatedByProvider": {
+          "name": "lastUpdatedByProvider",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contextWindow": {
+          "name": "contextWindow",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 128000
+        },
+        "maxOutputWindow": {
+          "name": "maxOutputWindow",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 4096
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Model_providerId_ModelProvider_id_fk": {
+          "name": "Model_providerId_ModelProvider_id_fk",
+          "tableFrom": "Model",
+          "tableTo": "ModelProvider",
+          "columnsFrom": [
+            "providerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ModelProvider": {
+      "name": "ModelProvider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "apiKey": {
+          "name": "apiKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "apiUrl": {
+          "name": "apiUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ModelProvider_name_unique": {
+          "name": "ModelProvider_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Persona": {
+      "name": "Persona",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "Persona_name_unique": {
+          "name": "Persona_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Command": {
+      "name": "Command",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "argumentLabel": {
+          "name": "argumentLabel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "Command_name_unique": {
+          "name": "Command_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.McpServer": {
+      "name": "McpServer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transport_type": {
+          "name": "transport_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "tool_approvals": {
+          "name": "tool_approvals",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "McpServer_name_unique": {
+          "name": "McpServer_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WebSearchConfig": {
+      "name": "WebSearchConfig",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "apiKey": {
+          "name": "apiKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "WebSearchConfig_type_unique": {
+          "name": "WebSearchConfig_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Workflow": {
+      "name": "Workflow",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "workflow_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "latestVersion": {
+          "name": "latestVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowRun": {
+      "name": "WorkflowRun",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowVersionId": {
+          "name": "workflowVersionId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflow_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "WorkflowRun_workflowId_Workflow_id_fk": {
+          "name": "WorkflowRun_workflowId_Workflow_id_fk",
+          "tableFrom": "WorkflowRun",
+          "tableTo": "Workflow",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "WorkflowRun_workflowVersionId_WorkflowVersion_id_fk": {
+          "name": "WorkflowRun_workflowVersionId_WorkflowVersion_id_fk",
+          "tableFrom": "WorkflowRun",
+          "tableTo": "WorkflowVersion",
+          "columnsFrom": [
+            "workflowVersionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowRunEvent": {
+      "name": "WorkflowRunEvent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workflowRunId": {
+          "name": "workflowRunId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "workflow_run_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflow_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "WorkflowRunEvent_workflowRunId_WorkflowRun_id_fk": {
+          "name": "WorkflowRunEvent_workflowRunId_WorkflowRun_id_fk",
+          "tableFrom": "WorkflowRunEvent",
+          "tableTo": "WorkflowRun",
+          "columnsFrom": [
+            "workflowRunId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowVersion": {
+      "name": "WorkflowVersion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_version_workflow_id_version_idx": {
+          "name": "workflow_version_workflow_id_version_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "WorkflowVersion_workflowId_Workflow_id_fk": {
+          "name": "WorkflowVersion_workflowId_Workflow_id_fk",
+          "tableFrom": "WorkflowVersion",
+          "tableTo": "Workflow",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.message_role": {
+      "name": "message_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "assistant",
+        "system"
+      ]
+    },
+    "public.model_modality": {
+      "name": "model_modality",
+      "schema": "public",
+      "values": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ]
+    },
+    "public.model_status": {
+      "name": "model_status",
+      "schema": "public",
+      "values": [
+        "not_defined",
+        "deprecated"
+      ]
+    },
+    "public.workflow_run_event_type": {
+      "name": "workflow_run_event_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "started",
+        "progress",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.workflow_run_status": {
+      "name": "workflow_run_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.workflow_status": {
+      "name": "workflow_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "archived"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -232,6 +232,20 @@
       "when": 1778258031718,
       "tag": "0032_aberrant_oracle",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1778330471695,
+      "tag": "0033_special_emma_frost",
+      "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1778331047270,
+      "tag": "0034_yummy_robin_chapel",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/database/schema/schema.ts
+++ b/packages/core/database/schema/schema.ts
@@ -4,3 +4,5 @@ export * from './personaSchema';
 export * from './commandSchema';
 export * from './mcpServerSchema';
 export * from './webSearchConfigSchema';
+
+export * from './workflowSchema';

--- a/packages/core/database/schema/workflowSchema.ts
+++ b/packages/core/database/schema/workflowSchema.ts
@@ -1,0 +1,103 @@
+import { relations } from 'drizzle-orm';
+import { integer, jsonb, pgEnum, pgTable, text, timestamp, uniqueIndex, uuid } from 'drizzle-orm/pg-core';
+
+export const workflowStatus = pgEnum('workflow_status', ['active', 'archived']);
+export const workflowRunStatus = pgEnum('workflow_run_status', [
+    'queued',
+    'running',
+    'completed',
+    'failed',
+    'cancelled',
+]);
+
+export const workflowRunEventType = pgEnum('workflow_run_event_type', [
+    'created',
+    'started',
+    'progress',
+    'completed',
+    'failed',
+    'cancelled',
+]);
+
+export const workflow = pgTable('Workflow', {
+    id: uuid('id').primaryKey().notNull().defaultRandom(),
+    title: text('title').notNull(),
+    summary: text('summary'),
+    status: workflowStatus('status').notNull().default('active'),
+    latestVersion: integer('latestVersion').notNull().default(1),
+    createdAt: timestamp('createdAt').notNull().defaultNow(),
+    updatedAt: timestamp('updatedAt').notNull().defaultNow(),
+});
+
+export const workflowVersion = pgTable('WorkflowVersion', {
+    id: uuid('id').primaryKey().notNull().defaultRandom(),
+    workflowId: uuid('workflowId')
+        .notNull()
+        .references(() => workflow.id, { onDelete: 'cascade' }),
+    version: integer('version').notNull(),
+    graph: jsonb('graph').notNull(),
+    createdAt: timestamp('createdAt').notNull().defaultNow(),
+    updatedAt: timestamp('updatedAt').notNull().defaultNow(),
+}, (table) => ({
+    workflowVersionPerWorkflow: uniqueIndex('workflow_version_workflow_id_version_idx').on(table.workflowId, table.version),
+}));
+
+export const workflowRun = pgTable('WorkflowRun', {
+    id: uuid('id').primaryKey().notNull().defaultRandom(),
+    workflowId: uuid('workflowId')
+        .notNull()
+        .references(() => workflow.id, { onDelete: 'cascade' }),
+    workflowVersionId: uuid('workflowVersionId')
+        .notNull()
+        .references(() => workflowVersion.id, { onDelete: 'restrict' }),
+    status: workflowRunStatus('status').notNull().default('queued'),
+    startedAt: timestamp('startedAt'),
+    completedAt: timestamp('completedAt'),
+    errorMessage: text('errorMessage'),
+    createdAt: timestamp('createdAt').notNull().defaultNow(),
+    updatedAt: timestamp('updatedAt').notNull().defaultNow(),
+});
+
+export const workflowRunEvent = pgTable('WorkflowRunEvent', {
+    id: uuid('id').primaryKey().notNull().defaultRandom(),
+    workflowRunId: uuid('workflowRunId')
+        .notNull()
+        .references(() => workflowRun.id, { onDelete: 'cascade' }),
+    eventType: workflowRunEventType('eventType').notNull(),
+    status: workflowRunStatus('status'),
+    message: text('message'),
+    payload: jsonb('payload'),
+    createdAt: timestamp('createdAt').notNull().defaultNow(),
+});
+
+export const workflowRelations = relations(workflow, ({ many }) => ({
+    versions: many(workflowVersion),
+    runs: many(workflowRun),
+}));
+
+export const workflowVersionRelations = relations(workflowVersion, ({ one, many }) => ({
+    workflow: one(workflow, {
+        fields: [workflowVersion.workflowId],
+        references: [workflow.id],
+    }),
+    runs: many(workflowRun),
+}));
+
+export const workflowRunRelations = relations(workflowRun, ({ one, many }) => ({
+    workflow: one(workflow, {
+        fields: [workflowRun.workflowId],
+        references: [workflow.id],
+    }),
+    version: one(workflowVersion, {
+        fields: [workflowRun.workflowVersionId],
+        references: [workflowVersion.id],
+    }),
+    events: many(workflowRunEvent),
+}));
+
+export const workflowRunEventRelations = relations(workflowRunEvent, ({ one }) => ({
+    workflowRun: one(workflowRun, {
+        fields: [workflowRunEvent.workflowRunId],
+        references: [workflowRun.id],
+    }),
+}));

--- a/packages/core/dto.ts
+++ b/packages/core/dto.ts
@@ -8,6 +8,10 @@ import {
     modelProvider,
     persona,
     webSearchConfig,
+    workflow,
+    workflowRun,
+    workflowRunEvent,
+    workflowVersion,
 } from './database/schema/schema';
 import { UIMessage } from 'ai';
 
@@ -137,3 +141,23 @@ export type McpServer = InferSelectModel<typeof mcpServer>;
 export type McpServerInsert = InferInsertModel<typeof mcpServer>;
 export type McpServerCreateInput = Omit<McpServerInsert, 'id' | 'createdAt' | 'updatedAt'>;
 export type McpServerUpdateInput = Partial<Omit<McpServerInsert, 'id' | 'createdAt' | 'updatedAt'>>;
+
+
+export interface WorkflowGraph {
+    nodes: Record<string, unknown>[];
+    edges: Record<string, unknown>[];
+    config?: Record<string, unknown>;
+}
+
+export type Workflow = InferSelectModel<typeof workflow>;
+export type WorkflowInsert = InferInsertModel<typeof workflow>;
+export type WorkflowCreateInput = Omit<WorkflowInsert, 'id' | 'createdAt' | 'updatedAt' | 'latestVersion' | 'status'>;
+
+export type WorkflowVersion = InferSelectModel<typeof workflowVersion>;
+export type WorkflowVersionInsert = InferInsertModel<typeof workflowVersion>;
+
+export type WorkflowRun = InferSelectModel<typeof workflowRun>;
+export type WorkflowRunInsert = InferInsertModel<typeof workflowRun>;
+
+export type WorkflowRunEvent = InferSelectModel<typeof workflowRunEvent>;
+export type WorkflowRunEventInsert = InferInsertModel<typeof workflowRunEvent>;

--- a/packages/core/inversify.config.ts
+++ b/packages/core/inversify.config.ts
@@ -18,6 +18,10 @@ import { McpClientManager } from './services/McpClientManager';
 import {WebSearchConfigRepository} from "./repositories/WebSearchConfigRepository";
 import {WebSearchConfigService} from "./services/WebSearchConfigService";
 import {Base64SecretStore, type SecretStore} from "./platform/SecretStore";
+import { WorkflowRepository } from './repositories/WorkflowRepository';
+import { WorkflowRunRepository } from './repositories/WorkflowRunRepository';
+import { WorkflowService } from './services/WorkflowService';
+import { WorkflowRunService } from './services/WorkflowRunService';
 
 const coreContainer = new Container();
 
@@ -38,6 +42,8 @@ coreContainer.bind<McpServerRepository>(CORETYPES.McpServerRepository).to(McpSer
 coreContainer.bind<WebSearchConfigRepository>(CORETYPES.WebSearchConfigRepository)
     .to(WebSearchConfigRepository)
     .inSingletonScope();
+coreContainer.bind<WorkflowRepository>(CORETYPES.WorkflowRepository).to(WorkflowRepository).inSingletonScope();
+coreContainer.bind<WorkflowRunRepository>(CORETYPES.WorkflowRunRepository).to(WorkflowRunRepository).inSingletonScope();
 
 // Services
 coreContainer.bind<ChatService>(CORETYPES.ChatService).to(ChatService).inSingletonScope();
@@ -50,5 +56,7 @@ coreContainer.bind<McpClientManager>(CORETYPES.McpClientManager).to(McpClientMan
 coreContainer.bind<WebSearchConfigService>(CORETYPES.WebSearchConfigService)
     .to(WebSearchConfigService)
     .inSingletonScope();
+coreContainer.bind<WorkflowService>(CORETYPES.WorkflowService).to(WorkflowService).inSingletonScope();
+coreContainer.bind<WorkflowRunService>(CORETYPES.WorkflowRunService).to(WorkflowRunService).inSingletonScope();
 
 export { coreContainer };

--- a/packages/core/repositories/WorkflowRepository.ts
+++ b/packages/core/repositories/WorkflowRepository.ts
@@ -1,0 +1,95 @@
+import { inject, injectable } from 'inversify';
+import { desc, eq, ilike, or, sql, SQL } from 'drizzle-orm';
+import { DatabaseManager } from '../database/DatabaseManager';
+import { workflow, workflowVersion } from '../database/schema/schema';
+import { CORETYPES } from '../types/types';
+import { Workflow, WorkflowCreateInput, WorkflowGraph, WorkflowVersion } from '../dto';
+
+@injectable()
+export class WorkflowRepository {
+    private db;
+
+    constructor(@inject(CORETYPES.DatabaseManager) databaseManager: DatabaseManager) {
+        this.db = databaseManager.getInstance();
+    }
+
+    // Fetches workflows with optional fuzzy matching for title and summary.
+    public async getAll(searchQuery: string | null): Promise<Workflow[]> {
+        const conditions: SQL[] = [];
+        if (searchQuery?.trim()) {
+            const query = `%${searchQuery.trim()}%`;
+            conditions.push(ilike(workflow.title, query));
+            conditions.push(ilike(workflow.summary, query));
+        }
+
+        const whereClause = conditions.length > 0 ? or(...conditions) : undefined;
+        return this.db.select().from(workflow).where(whereClause).orderBy(desc(workflow.updatedAt));
+    }
+
+    // Looks up a workflow by id for CRUD flows.
+    public async getById(id: string): Promise<Workflow | undefined> {
+        return this.db.query.workflow.findFirst({ where: eq(workflow.id, id) });
+    }
+
+    // Creates a workflow and stores its first graph version in one transaction.
+    public async create(input: WorkflowCreateInput, graph: WorkflowGraph): Promise<Workflow> {
+        return this.db.transaction(async (tx) => {
+            const [createdWorkflow] = await tx.insert(workflow).values({
+                title: input.title,
+                summary: input.summary,
+            }).returning();
+
+            await tx.insert(workflowVersion).values({
+                workflowId: createdWorkflow.id,
+                version: 1,
+                graph,
+            });
+
+            return createdWorkflow;
+        });
+    }
+
+    // Updates mutable workflow metadata.
+    public async update(id: string, updates: Partial<WorkflowCreateInput>): Promise<Workflow | undefined> {
+        const [updated] = await this.db.update(workflow).set({ ...updates, updatedAt: new Date() }).where(eq(workflow.id, id)).returning();
+        return updated;
+    }
+
+    // Deletes a workflow and cascades related versions/runs/events.
+    public async delete(id: string): Promise<void> {
+        await this.db.delete(workflow).where(eq(workflow.id, id));
+    }
+
+    // Loads all versions for a workflow in descending order.
+    public async getVersionsForWorkflow(workflowId: string): Promise<WorkflowVersion[]> {
+        return this.db.query.workflowVersion.findMany({
+            where: eq(workflowVersion.workflowId, workflowId),
+            orderBy: desc(workflowVersion.version),
+        });
+    }
+
+    // Creates the next immutable version for a workflow graph snapshot.
+    public async createVersion(workflowId: string, graph: WorkflowGraph): Promise<WorkflowVersion> {
+        return this.db.transaction(async (tx) => {
+            const [workflowRow] = await tx
+                .update(workflow)
+                .set({ latestVersion: sql`${workflow.latestVersion} + 1`, updatedAt: new Date() })
+                .where(eq(workflow.id, workflowId))
+                .returning({ latestVersion: workflow.latestVersion });
+
+            if (!workflowRow) {
+                throw new Error(`Workflow not found: ${workflowId}`);
+            }
+
+            const [createdVersion] = await tx
+                .insert(workflowVersion)
+                .values({
+                    workflowId,
+                    version: workflowRow.latestVersion,
+                    graph,
+                })
+                .returning();
+            return createdVersion;
+        });
+    }
+}

--- a/packages/core/repositories/WorkflowRunRepository.ts
+++ b/packages/core/repositories/WorkflowRunRepository.ts
@@ -1,7 +1,7 @@
 import { inject, injectable } from 'inversify';
 import { and, desc, eq } from 'drizzle-orm';
 import { DatabaseManager } from '../database/DatabaseManager';
-import { workflowRun, workflowRunEvent } from '../database/schema/schema';
+import { workflowRun, workflowRunEvent, workflowVersion } from '../database/schema/schema';
 import { CORETYPES } from '../types/types';
 import { WorkflowRun, WorkflowRunEvent, WorkflowRunEventInsert, WorkflowRunInsert } from '../dto';
 
@@ -15,6 +15,18 @@ export class WorkflowRunRepository {
 
     // Creates a run record for workflow execution lifecycle tracking.
     public async create(input: WorkflowRunInsert): Promise<WorkflowRun> {
+        const matchingVersion = await this.db.query.workflowVersion.findFirst({
+            where: and(
+                eq(workflowVersion.id, input.workflowVersionId),
+                eq(workflowVersion.workflowId, input.workflowId),
+            ),
+            columns: { id: true },
+        });
+
+        if (!matchingVersion) {
+            throw new Error('Workflow version does not belong to the provided workflow');
+        }
+
         const [created] = await this.db.insert(workflowRun).values(input).returning();
         return created;
     }

--- a/packages/core/repositories/WorkflowRunRepository.ts
+++ b/packages/core/repositories/WorkflowRunRepository.ts
@@ -1,0 +1,55 @@
+import { inject, injectable } from 'inversify';
+import { and, desc, eq } from 'drizzle-orm';
+import { DatabaseManager } from '../database/DatabaseManager';
+import { workflowRun, workflowRunEvent } from '../database/schema/schema';
+import { CORETYPES } from '../types/types';
+import { WorkflowRun, WorkflowRunEvent, WorkflowRunEventInsert, WorkflowRunInsert } from '../dto';
+
+@injectable()
+export class WorkflowRunRepository {
+    private db;
+
+    constructor(@inject(CORETYPES.DatabaseManager) databaseManager: DatabaseManager) {
+        this.db = databaseManager.getInstance();
+    }
+
+    // Creates a run record for workflow execution lifecycle tracking.
+    public async create(input: WorkflowRunInsert): Promise<WorkflowRun> {
+        const [created] = await this.db.insert(workflowRun).values(input).returning();
+        return created;
+    }
+
+    // Fetches a run with its event timeline for status views.
+    public async getById(id: string): Promise<(WorkflowRun & { events: WorkflowRunEvent[] }) | undefined> {
+        return this.db.query.workflowRun.findFirst({
+            where: eq(workflowRun.id, id),
+            with: { events: { orderBy: desc(workflowRunEvent.createdAt) } },
+        });
+    }
+
+    // Lists runs for a workflow ordered by recency.
+    public async getByWorkflowId(workflowId: string): Promise<WorkflowRun[]> {
+        return this.db.select().from(workflowRun).where(and(eq(workflowRun.workflowId, workflowId))).orderBy(desc(workflowRun.createdAt));
+    }
+
+    // Persists run status changes and timestamps.
+    public async updateStatus(id: string, status: WorkflowRun['status'], errorMessage?: string | null): Promise<WorkflowRun | undefined> {
+        const now = new Date();
+        const startedAt = status === 'running' ? now : undefined;
+        const completedAt = ['completed', 'failed', 'cancelled'].includes(status) ? now : undefined;
+        const [updated] = await this.db.update(workflowRun).set({
+            status,
+            errorMessage: errorMessage ?? null,
+            startedAt,
+            completedAt,
+            updatedAt: now,
+        }).where(eq(workflowRun.id, id)).returning();
+        return updated;
+    }
+
+    // Appends timeline events for auditability.
+    public async addEvent(input: WorkflowRunEventInsert): Promise<WorkflowRunEvent> {
+        const [event] = await this.db.insert(workflowRunEvent).values(input).returning();
+        return event;
+    }
+}

--- a/packages/core/services/WorkflowRunService.test.ts
+++ b/packages/core/services/WorkflowRunService.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WorkflowRun, WorkflowRunEvent } from '../dto';
+import type { WorkflowRunRepository } from '../repositories/WorkflowRunRepository';
+import { WorkflowRunService } from './WorkflowRunService';
+
+describe('WorkflowRunService', () => {
+    let repository: WorkflowRunRepository;
+    let service: WorkflowRunService;
+
+    beforeEach(() => {
+        repository = {
+            create: vi.fn(),
+            getById: vi.fn(),
+            getByWorkflowId: vi.fn(),
+            updateStatus: vi.fn(),
+            addEvent: vi.fn(),
+        } as unknown as WorkflowRunRepository;
+        service = new WorkflowRunService(repository);
+    });
+
+    it('starts a run and records created event', async () => {
+        const run = { id: 'r1', status: 'queued' } as WorkflowRun;
+        (repository.create as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(run);
+
+        const result = await service.startRun({ workflowId: 'w1', workflowVersionId: 'v1' } as unknown as WorkflowRun);
+
+        expect(result).toEqual(run);
+        expect(repository.create).toHaveBeenCalledWith(expect.objectContaining({ status: 'queued' }));
+        expect(repository.addEvent).toHaveBeenCalledWith(expect.objectContaining({ eventType: 'created' }));
+    });
+
+    it('updates run status, supports cancel, and fetches status timeline', async () => {
+        const run = { id: 'r1', status: 'running' } as WorkflowRun;
+        const timeline = { ...run, events: [] as WorkflowRunEvent[] };
+        (repository.updateStatus as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(run);
+        (repository.getById as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(timeline);
+
+        await expect(service.updateRunStatus('r1', 'running', 'started')).resolves.toEqual(run);
+        await expect(service.cancelRun('r1')).resolves.toEqual(run);
+        await expect(service.getRunStatus('r1')).resolves.toEqual(timeline);
+
+        expect(repository.addEvent).toHaveBeenCalledWith(expect.objectContaining({ eventType: 'started' }));
+        expect(repository.addEvent).toHaveBeenCalledWith(expect.objectContaining({ eventType: 'cancelled' }));
+    });
+
+    it('maps queued status updates to created events', async () => {
+        const run = { id: 'r2', status: 'queued' } as WorkflowRun;
+        (repository.updateStatus as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(run);
+
+        await expect(service.updateRunStatus('r2', 'queued', 're-queued')).resolves.toEqual(run);
+
+        expect(repository.addEvent).toHaveBeenCalledWith(expect.objectContaining({
+            workflowRunId: 'r2',
+            eventType: 'created',
+            status: 'queued',
+        }));
+    });
+});

--- a/packages/core/services/WorkflowRunService.ts
+++ b/packages/core/services/WorkflowRunService.ts
@@ -1,0 +1,56 @@
+import { inject, injectable } from 'inversify';
+import { WorkflowRun, WorkflowRunEvent, WorkflowRunInsert } from '../dto';
+import { WorkflowRunRepository } from '../repositories/WorkflowRunRepository';
+import { CORETYPES } from '../types/types';
+
+@injectable()
+export class WorkflowRunService {
+    constructor(@inject(CORETYPES.WorkflowRunRepository) private workflowRunRepository: WorkflowRunRepository) {}
+
+    // Starts a workflow run and writes initial lifecycle events.
+    public async startRun(input: WorkflowRunInsert): Promise<WorkflowRun> {
+        const run = await this.workflowRunRepository.create({ ...input, status: 'queued' });
+        await this.workflowRunRepository.addEvent({
+            workflowRunId: run.id,
+            eventType: 'created',
+            status: 'queued',
+            message: 'Run created',
+        });
+        return run;
+    }
+
+    // Updates run status and mirrors it in the event timeline.
+    public async updateRunStatus(runId: string, status: WorkflowRun['status'], message?: string): Promise<WorkflowRun | undefined> {
+        const run = await this.workflowRunRepository.updateStatus(runId, status, status === 'failed' ? message : null);
+        if (!run) return undefined;
+
+        await this.workflowRunRepository.addEvent({
+            workflowRunId: runId,
+            eventType: this.mapStatusToEventType(status),
+            status,
+            message: message ?? `Run status updated to ${status}`,
+        });
+        return run;
+    }
+
+    // Cancels an active run and records the cancellation event.
+    public async cancelRun(runId: string, message?: string): Promise<WorkflowRun | undefined> {
+        return this.updateRunStatus(runId, 'cancelled', message ?? 'Run cancelled');
+    }
+
+    // Retrieves the latest status plus event timeline for a run.
+    public async getRunStatus(runId: string): Promise<(WorkflowRun & { events: WorkflowRunEvent[] }) | undefined> {
+        return this.workflowRunRepository.getById(runId);
+    }
+
+    // Keeps run status values aligned with the constrained event enum values.
+    private mapStatusToEventType(status: WorkflowRun['status']): WorkflowRunEvent['eventType'] {
+        if (status === 'queued') {
+            return 'created';
+        }
+        if (status === 'running') {
+            return 'started';
+        }
+        return status;
+    }
+}

--- a/packages/core/services/WorkflowService.test.ts
+++ b/packages/core/services/WorkflowService.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Workflow, WorkflowGraph, WorkflowVersion } from '../dto';
+import type { WorkflowRepository } from '../repositories/WorkflowRepository';
+import { WorkflowService } from './WorkflowService';
+
+describe('WorkflowService', () => {
+    let repository: WorkflowRepository;
+    let service: WorkflowService;
+
+    beforeEach(() => {
+        repository = {
+            getAll: vi.fn(),
+            getById: vi.fn(),
+            create: vi.fn(),
+            update: vi.fn(),
+            delete: vi.fn(),
+            getVersionsForWorkflow: vi.fn(),
+            createVersion: vi.fn(),
+        } as unknown as WorkflowRepository;
+        service = new WorkflowService(repository);
+    });
+
+    it('delegates CRUD/search and versioning operations', async () => {
+        const workflow = { id: 'w1' } as Workflow;
+        const version = { id: 'v1' } as WorkflowVersion;
+        const graph = { nodes: [], edges: [] } as WorkflowGraph;
+
+        (repository.getAll as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([workflow]);
+        (repository.getById as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(workflow);
+        (repository.create as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(workflow);
+        (repository.update as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(workflow);
+        (repository.getVersionsForWorkflow as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([version]);
+        (repository.createVersion as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(version);
+
+        await expect(service.getAllWorkflows('abc')).resolves.toEqual([workflow]);
+        await expect(service.getWorkflowById('w1')).resolves.toEqual(workflow);
+        await expect(service.createWorkflow({ title: 'T', summary: 'S' }, graph)).resolves.toEqual(workflow);
+        await expect(service.updateWorkflow('w1', { title: 'T2' })).resolves.toEqual(workflow);
+        await service.deleteWorkflow('w1');
+        await expect(service.getWorkflowVersions('w1')).resolves.toEqual([version]);
+        await expect(service.createWorkflowVersion('w1', graph)).resolves.toEqual(version);
+
+        expect(repository.delete).toHaveBeenCalledWith('w1');
+    });
+});

--- a/packages/core/services/WorkflowService.ts
+++ b/packages/core/services/WorkflowService.ts
@@ -1,0 +1,44 @@
+import { inject, injectable } from 'inversify';
+import { Workflow, WorkflowCreateInput, WorkflowGraph, WorkflowVersion } from '../dto';
+import { WorkflowRepository } from '../repositories/WorkflowRepository';
+import { CORETYPES } from '../types/types';
+
+@injectable()
+export class WorkflowService {
+    constructor(@inject(CORETYPES.WorkflowRepository) private workflowRepository: WorkflowRepository) {}
+
+    // Provides search and listing support for workflow catalog screens.
+    public async getAllWorkflows(searchQuery: string | null): Promise<Workflow[]> {
+        return this.workflowRepository.getAll(searchQuery);
+    }
+
+    // Loads a single workflow for details and editing contexts.
+    public async getWorkflowById(id: string): Promise<Workflow | undefined> {
+        return this.workflowRepository.getById(id);
+    }
+
+    // Creates a workflow plus its initial version snapshot.
+    public async createWorkflow(input: WorkflowCreateInput, graph: WorkflowGraph): Promise<Workflow> {
+        return this.workflowRepository.create(input, graph);
+    }
+
+    // Updates workflow metadata that is safe to change in-place.
+    public async updateWorkflow(id: string, updates: Partial<WorkflowCreateInput>): Promise<Workflow | undefined> {
+        return this.workflowRepository.update(id, updates);
+    }
+
+    // Removes a workflow and all dependent records.
+    public async deleteWorkflow(id: string): Promise<void> {
+        await this.workflowRepository.delete(id);
+    }
+
+    // Returns all version snapshots for a workflow.
+    public async getWorkflowVersions(workflowId: string): Promise<WorkflowVersion[]> {
+        return this.workflowRepository.getVersionsForWorkflow(workflowId);
+    }
+
+    // Produces a new immutable workflow version from a graph snapshot.
+    public async createWorkflowVersion(workflowId: string, graph: WorkflowGraph): Promise<WorkflowVersion> {
+        return this.workflowRepository.createVersion(workflowId, graph);
+    }
+}

--- a/packages/core/types/types.ts
+++ b/packages/core/types/types.ts
@@ -9,6 +9,8 @@ const CORETYPES = {
     CommandRepository: Symbol.for('CommandRepository'),
     McpServerRepository: Symbol.for('McpServerRepository'),
     WebSearchConfigRepository: Symbol.for("WebSearchConfigRepository"),
+    WorkflowRepository: Symbol.for('WorkflowRepository'),
+    WorkflowRunRepository: Symbol.for('WorkflowRunRepository'),
     // services
     ChatService: Symbol.for('ChatService'),
     MessageService: Symbol.for('MessageService'),
@@ -18,6 +20,8 @@ const CORETYPES = {
     McpServerService: Symbol.for('McpServerService'),
     McpClientManager: Symbol.for('McpClientManager'),
     WebSearchConfigService: Symbol.for("WebSearchConfigService"),
+    WorkflowService: Symbol.for('WorkflowService'),
+    WorkflowRunService: Symbol.for('WorkflowRunService'),
 };
 
 export { CORETYPES };


### PR DESCRIPTION
### Motivation
- Introduce a first-class "workflow" domain to manage workflow definitions, immutable version snapshots, execution runs, and run events for lifecycle/auditability.
- Provide DB-level types and constraints so runs and versions are tracked with referential integrity and efficient version lookups.

### Description
- Add Postgres migrations `migrations/0033_special_emma_frost.sql` and `migrations/0034_yummy_robin_chapel.sql` and updated migration snapshots to create enums, tables (`Workflow`, `WorkflowVersion`, `WorkflowRun`, `WorkflowRunEvent`) and a unique index on `(workflowId, version)`.
- Implement a Drizzle schema in `packages/core/database/schema/workflowSchema.ts` and export it from `packages/core/database/schema/schema.ts`.
- Extend DTOs in `packages/core/dto.ts` with `Workflow`, `WorkflowVersion`, `WorkflowRun`, `WorkflowRunEvent` types and a `WorkflowGraph` shape.
- Add repository implementations `WorkflowRepository` and `WorkflowRunRepository` to handle CRUD, version creation, run lifecycle updates, and event appends.
- Add services `WorkflowService` and `WorkflowRunService` encapsulating business logic (search, versioning, start/update/cancel runs and event mapping) and register them in DI via `packages/core/inversify.config.ts` and `packages/core/types/types.ts`.
- Add unit tests `packages/core/services/WorkflowService.test.ts` and `packages/core/services/WorkflowRunService.test.ts` covering main service flows and event mapping.

### Testing
- Ran the unit tests with `vitest` for the new services and the added tests `WorkflowService.test.ts` and `WorkflowRunService.test.ts`, and they passed.
- Verified migrations and Drizzle schema match by adding snapshot metadata files `migrations/meta/0033_snapshot.json` and `migrations/meta/0034_snapshot.json` to reflect the new DB state.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff2ae2b11883228b587a75d6d2b234)