### PR TITLE
Fix PR checks: lint warning and test timeouts

### DIFF
--- a/packages/core/repositories/MessageRepository.test.ts
+++ b/packages/core/repositories/MessageRepository.test.ts
@@ -18,7 +18,7 @@ describe('MessageRepository', () => {
             getInstance: () => testDb.db,
         } as unknown as DatabaseManager;
         repository = new MessageRepository(databaseManager);
-    });
+    }, 20000);
 
     afterAll(async () => {
         await testDb.close();

--- a/packages/core/repositories/ModelProviderRepository.test.ts
+++ b/packages/core/repositories/ModelProviderRepository.test.ts
@@ -23,7 +23,7 @@ describe('ModelProviderRepository', () => {
             getInstance: () => testDb.db,
         } as unknown as DatabaseManager;
         repository = new ModelProviderRepository(databaseManager, secretStore as SecretStore);
-    });
+    }, 20000);
 
     afterAll(async () => {
         await testDb.close();

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -31,19 +31,20 @@ describe('preload index', () => {
         const { api } = await import('./api');
         await import('./index');
 
-    expect(exposeInMainWorld).toHaveBeenCalledWith("api", api)
-    expect(Object.keys(api)).toEqual([
-      "chat",
-      "modelProvider",
-      "message",
-      "persona",
-      "command",
-      "mcpServer",
-      "webSearch",
-      "streaming",
-    ])
-    expect(api).not.toHaveProperty("ipcRenderer")
-  })
+        expect(exposeInMainWorld).toHaveBeenCalledWith('api', api);
+        expect(Object.keys(api)).toEqual([
+            'chat',
+            'modelProvider',
+            'message',
+            'persona',
+            'command',
+            'mcpServer',
+            'webSearch',
+            'workflow',
+            'streaming',
+        ]);
+        expect(api).not.toHaveProperty('ipcRenderer');
+    });
 
     it('wires streaming listeners and removes them', async () => {
         const { api } = await import('./api');

--- a/src/renderer/src/components/messages.tsx
+++ b/src/renderer/src/components/messages.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import equal from 'fast-deep-equal';
 import type { UseChatHelpers } from '@ai-sdk/react';
 import {


### PR DESCRIPTION
### Motivation
- Clear CI/PR failures caused by a lint warning and flaky test timeouts during local PR checks.
- Ensure the preload API test reflects the current `api` surface shape so unit tests mirror runtime exports.
- Prevent intermittent `beforeAll` hook timeouts while initializing the ephemeral test DB in core repository tests.

### Description
- Removed an unused `useState` import in `src/renderer/src/components/messages.tsx` to resolve an ESLint warning.
- Updated `src/preload/index.test.ts` to expect the `workflow` namespace on the exposed `api` and normalized test formatting.
- Increased the `beforeAll` hook timeout to `20000ms` in `packages/core/repositories/ModelProviderRepository.test.ts` and `packages/core/repositories/MessageRepository.test.ts` to avoid DB initialization timeouts.

### Testing
- Ran `npm install` and resolved dependencies successfully with `npm run lint` (root) completing without errors.
- Ran `cd src/renderer && npm run lint` which produced no errors after the fix.
- Ran `npm run test` (Vitest) and confirmed all tests passed: `32` test files and `129` tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00155223f883229d9e1f0cdc026570)