### PR TITLE
Centralize chat state and sync persistence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ Before coding, decide **where the feature belongs**. Default to keeping the rend
 
 1. **Pure UI/UX change (layout, styling, components, interaction)**  
    → `src/renderer/src/...`
+   → Chat UI state belongs in the Redux store/runtime layer under `src/renderer/src/store/*`, not directly in `page.tsx`.
 
 2. **Needs OS access / Electron APIs / filesystem / app lifecycle**  
    → `src/main/...`  
@@ -55,6 +56,7 @@ Before coding, decide **where the feature belongs**. Default to keeping the rend
 4. **AI/model provider logic** (providers, streaming, prompt assembly, tool calls)  
    → Prefer `packages/core/...` for provider registry + model selection logic.  
    → Keep streaming orchestration that needs `webContents.send` in `src/main/controllers/StreamingChatController.ts`.
+   → Keep AI SDK chat runtimes in the renderer runtime registry, and persist message snapshots through validated IPC sync.
 
 5. **Shared types/DTOs**  
    → `packages/core/dto.ts` (and types under `packages/core/types/`)
@@ -162,7 +164,10 @@ When you change code, always run:
 
 1. Lints: `npm run lint` (root) and `npm run lint` in `src/renderer`
 2. Tests: add/run targeted tests first, then full suite(`npm run test`) and Coverage(`npm run test:coverage`)
-3. Build check (after every major change): Full build(`npm run package`) and start(`npm run dev`)
+3. Build check for every code change:
+    - Renderer build: `cd src/renderer && npm run build`
+    - Full app package build: `npm run package`
+4. Start check when the change affects runtime wiring or UX: `npm run dev`
 
 ## 5) Testing policy (strict, 100%+ mindset)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -50,6 +50,10 @@ Cosmo Studio is an Electron desktop application with a static-exported Next.js U
 
 - Next.js App Router UI.
 - Must use `window.api` for all privileged/data operations.
+- Chat UI state is owned by Redux Toolkit under `src/renderer/src/store/*`.
+    - `page.tsx` renders from selectors and dispatches thunks.
+    - AI SDK `Chat` instances live in a module-level runtime registry so streams survive route changes and multiple chats can stream in parallel.
+    - Runtime message snapshots are mirrored to Redux, then persisted through the message sync IPC queue.
 - Production output is static (`next.config.ts` uses `output: "export"`), written to `src/renderer/out/`.
 
 ### Core package (`packages/core`)
@@ -63,10 +67,18 @@ Cosmo Studio is an Electron desktop application with a static-exported Next.js U
 
 ### Command flow (high-level)
 
-1. Renderer gathers commands for UI (settings + dropdown) via `window.api.command.listAll()`.
+1. Renderer gathers commands for UI (settings + dropdown) through Redux thunks calling `window.api.command.listAll()`.
 2. User submits a command (typed or selected).
-3. Main resolves the command through `CommandController` → `CommandService`.
+3. A chat thunk resolves the command through `CommandController` → `CommandService`.
 4. The resolved prompt is sent through the normal chat streaming pipeline.
+
+### Chat persistence flow (high-level)
+
+1. Renderer dispatches chat thunks for history, selection, model/persona updates, sending, stop, regenerate, and tool approvals.
+2. A per-chat AI SDK runtime streams through `src/renderer/src/chat-transport.ts`.
+3. Each runtime message update updates Redux and enqueues `message:syncForChat`.
+4. Main validates the sync payload and `MessageRepository.syncForChat` accepts only newer per-chat sequence numbers.
+5. `StreamingChatController` only streams model output; it no longer writes user/assistant messages directly to the database.
 
 ## Build pipeline (how packaging works)
 

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -19,6 +19,16 @@ Cosmo Studio uses Drizzle ORM with PGlite (embedded Postgres) and runs migration
 - `Chat`, `Message`
 - `ModelProvider`, `Model`
 - `Persona`
+- `Command`
+- `McpServer`
+
+## Chat/message persistence
+
+- `Chat.syncVersion` stores the latest accepted renderer sync sequence.
+- `Message.uiMessageId` stores the AI SDK client message id.
+- `Message.uiMessage` stores the serialized AI SDK `UIMessage` snapshot.
+- Legacy `Message.text`, `Message.reasoning`, and `Message.modelIdentifier` remain populated for previews, search/debuggability, and backwards compatibility.
+- `MessageRepository.syncForChat` replaces a chat's stored message snapshot only when the incoming sequence is newer than `Chat.syncVersion`.
 
 ## Local storage location
 

--- a/docs/IPC.md
+++ b/docs/IPC.md
@@ -44,6 +44,20 @@ Streaming uses fire-and-forget channels plus renderer subscriptions:
     - `src/renderer/src/chat-transport.ts` (AI SDK transport)
     - `src/preload/api.ts` (subscription helpers)
 
+### Chat message sync
+
+The chat renderer persists AI SDK UI state through `message:syncForChat`.
+
+- Request DTO: `ChatMessageSyncInput`
+    - `chatId`
+    - monotonic per-chat `sequence`
+    - serialized `UIMessage[]`
+- Response DTO: `ChatMessageSyncAck`
+    - `accepted: false` means main ignored a stale sequence.
+- The controller validates the payload with `zod`.
+- The repository replaces the stored message snapshot for that chat inside one transaction and updates chat preview fields.
+- Streaming chunks still use `${streamChannel}-data/end/error`; final persistence does not happen in `StreamingChatController`.
+
 ## Adding/changing an IPC API (required steps)
 
 1. Implement the new handler in a controller:
@@ -51,6 +65,7 @@ Streaming uses fire-and-forget channels plus renderer subscriptions:
 2. Validate inputs (prefer `zod`) at the boundary.
 3. Bind the controller (if new) in `src/main/inversify.config.ts`.
 4. Run `npm run generate-api`.
+    - If unrelated project type errors block codegen, fix those first; `src/preload/api.ts` should remain generated output plus only narrowly scoped manual repair when the generator cannot express an existing signature.
 5. Update renderer usage through `window.api`.
 6. Add tests covering success + failure paths.
 

--- a/docs/RENDERER_DESIGN.md
+++ b/docs/RENDERER_DESIGN.md
@@ -53,8 +53,11 @@ This document captures UI/UX conventions so new features match the existing Cosm
 - Streaming chat:
     - Always handle failure states (toast + recoverable UI).
     - Clean up IPC listeners when streams end/cancel.
+    - Render chat messages/status from Redux, not component-local `useChat` state.
+    - Keep AI SDK `Chat` runtimes outside React component lifecycle so route changes do not drop active streams.
 - Commands:
     - List commands dynamically (built-ins + custom).
     - Allow optional single-argument input and show hints in the UI.
 - Errors:
+    - Use the centralized chat thunk/middleware path for chat IPC logging and toasts.
     - Use `sonner` for user-facing errors; use `logger` for diagnostic logs.

--- a/migrations/0032_mysterious_wrecking_crew.sql
+++ b/migrations/0032_mysterious_wrecking_crew.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "Chat" ADD COLUMN "syncVersion" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "Message" ADD COLUMN "uiMessageId" text;--> statement-breakpoint
+ALTER TABLE "Message" ADD COLUMN "uiMessage" jsonb;

--- a/migrations/meta/0032_snapshot.json
+++ b/migrations/meta/0032_snapshot.json
@@ -1,0 +1,629 @@
+{
+  "id": "9d71cb44-c464-4b67-9b65-cba7bedea1e8",
+  "prevId": "0a75326b-5efd-4196-a1b1-e0ba4326cbfc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.Chat": {
+      "name": "Chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "pinnedAt": {
+          "name": "pinnedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selectedProvider": {
+          "name": "selectedProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selectedModelId": {
+          "name": "selectedModelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selectedPersonaId": {
+          "name": "selectedPersonaId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected": {
+          "name": "selected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "syncVersion": {
+          "name": "syncVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastMessage": {
+          "name": "lastMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastMessageAt": {
+          "name": "lastMessageAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Message": {
+      "name": "Message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "message_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modelIdentifier": {
+          "name": "modelIdentifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uiMessageId": {
+          "name": "uiMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uiMessage": {
+          "name": "uiMessage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_chatId_Chat_id_fk": {
+          "name": "Message_chatId_Chat_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Model": {
+      "name": "Model",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modelId": {
+          "name": "modelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "attachment": {
+          "name": "attachment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "toolCall": {
+          "name": "toolCall",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "model_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'not_defined'"
+        },
+        "input_modalities": {
+          "name": "input_modalities",
+          "type": "model_modality[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "output_modalities": {
+          "name": "output_modalities",
+          "type": "model_modality[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "releaseDate": {
+          "name": "releaseDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastUpdatedByProvider": {
+          "name": "lastUpdatedByProvider",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contextWindow": {
+          "name": "contextWindow",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 128000
+        },
+        "maxOutputWindow": {
+          "name": "maxOutputWindow",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 4096
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Model_providerId_ModelProvider_id_fk": {
+          "name": "Model_providerId_ModelProvider_id_fk",
+          "tableFrom": "Model",
+          "tableTo": "ModelProvider",
+          "columnsFrom": [
+            "providerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ModelProvider": {
+      "name": "ModelProvider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "apiKey": {
+          "name": "apiKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "apiUrl": {
+          "name": "apiUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ModelProvider_name_unique": {
+          "name": "ModelProvider_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Persona": {
+      "name": "Persona",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "Persona_name_unique": {
+          "name": "Persona_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Command": {
+      "name": "Command",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "argumentLabel": {
+          "name": "argumentLabel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "Command_name_unique": {
+          "name": "Command_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.McpServer": {
+      "name": "McpServer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transport_type": {
+          "name": "transport_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "tool_approvals": {
+          "name": "tool_approvals",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "McpServer_name_unique": {
+          "name": "McpServer_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.message_role": {
+      "name": "message_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "assistant",
+        "system"
+      ]
+    },
+    "public.model_modality": {
+      "name": "model_modality",
+      "schema": "public",
+      "values": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ]
+    },
+    "public.model_status": {
+      "name": "model_status",
+      "schema": "public",
+      "values": [
+        "not_defined",
+        "deprecated"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1774881782000,
       "tag": "0031_drop_message_text_not_null",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1783696418499,
+      "tag": "0032_mysterious_wrecking_crew",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6421,6 +6421,32 @@
             "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
             "license": "MIT"
         },
+        "node_modules/@reduxjs/toolkit": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+            "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.0.0",
+                "@standard-schema/utils": "^0.3.0",
+                "immer": "^11.0.0",
+                "redux": "^5.0.1",
+                "redux-thunk": "^3.1.0",
+                "reselect": "^5.1.0"
+            },
+            "peerDependencies": {
+                "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+                "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "react": {
+                    "optional": true
+                },
+                "react-redux": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@rive-app/react-webgl2": {
             "version": "4.27.3",
             "resolved": "https://registry.npmjs.org/@rive-app/react-webgl2/-/react-webgl2-4.27.3.tgz",
@@ -6887,6 +6913,12 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
             "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "license": "MIT"
+        },
+        "node_modules/@standard-schema/utils": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+            "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
             "license": "MIT"
         },
         "node_modules/@stepperize/core": {
@@ -7980,6 +8012,12 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
             "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+            "license": "MIT"
+        },
+        "node_modules/@types/use-sync-external-store": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+            "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
             "license": "MIT"
         },
         "node_modules/@types/wrap-ansi": {
@@ -14836,6 +14874,16 @@
                 "node": ">= 4"
             }
         },
+        "node_modules/immer": {
+            "version": "11.1.11",
+            "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.11.tgz",
+            "integrity": "sha512-qzXuyXAkPySAGYkfsAwodDPWT8Zm7/Uo5BNt4BjhMhG5WlWyZZ4wQqnWwdS8kjlQ1Cwu6gjw3A6+0gTQwlyYtw==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/immer"
+            }
+        },
         "node_modules/import-fresh": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -19936,6 +19984,29 @@
                 "regenerator-runtime": "^0.13.2"
             }
         },
+        "node_modules/react-redux": {
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+            "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/use-sync-external-store": "^0.0.6",
+                "use-sync-external-store": "^1.4.0"
+            },
+            "peerDependencies": {
+                "@types/react": "^18.2.25 || ^19",
+                "react": "^18.0 || ^19",
+                "redux": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "redux": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/react-refresh": {
             "version": "0.18.0",
             "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
@@ -20220,6 +20291,21 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/redux": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+            "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+            "license": "MIT"
+        },
+        "node_modules/redux-thunk": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+            "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "redux": "^5.0.0"
             }
         },
         "node_modules/reflect-metadata": {
@@ -20546,6 +20632,12 @@
                 "type": "github",
                 "url": "https://github.com/sponsors/jet2jet"
             }
+        },
+        "node_modules/reselect": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+            "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+            "license": "MIT"
         },
         "node_modules/resolve": {
             "version": "1.22.11",
@@ -25105,6 +25197,7 @@
                 "@radix-ui/react-slot": "^1.2.4",
                 "@radix-ui/react-tooltip": "^1.2.8",
                 "@radix-ui/react-use-controllable-state": "^1.2.2",
+                "@reduxjs/toolkit": "^2.12.0",
                 "@rive-app/react-webgl2": "^4.26.2",
                 "@streamdown/cjk": "^1.0.1",
                 "@streamdown/code": "^1.0.1",
@@ -25136,6 +25229,7 @@
                 "react-jsx-parser": "^2.4.1",
                 "react-markdown": "10.1.0",
                 "react-mentions": "^4.4.10",
+                "react-redux": "^9.3.0",
                 "react-syntax-highlighter": "16.1.0",
                 "remark-gfm": "4.0.1",
                 "shiki": "^3.22.0",

--- a/packages/core/database/schema/chatSchema.ts
+++ b/packages/core/database/schema/chatSchema.ts
@@ -1,5 +1,6 @@
 import { relations } from 'drizzle-orm';
-import { pgTable, text, timestamp, uuid, boolean, pgEnum } from 'drizzle-orm/pg-core';
+import { boolean, integer, jsonb, pgEnum, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+import type { UIMessage } from 'ai';
 
 export const chat = pgTable('Chat', {
     id: uuid('id').primaryKey().notNull().defaultRandom(),
@@ -11,6 +12,7 @@ export const chat = pgTable('Chat', {
     selectedModelId: text('selectedModelId'),
     selectedPersonaId: uuid('selectedPersonaId'),
     selected: boolean().default(false),
+    syncVersion: integer('syncVersion').notNull().default(0),
     lastMessage: text('lastMessage'),
     lastMessageAt: timestamp('lastMessageAt'),
 });
@@ -30,6 +32,8 @@ export const message = pgTable('Message', {
     text: text('text'),
     reasoning: text('reasoning'),
     modelIdentifier: text('modelIdentifier'),
+    uiMessageId: text('uiMessageId'),
+    uiMessage: jsonb('uiMessage').$type<UIMessage>(),
     createdAt: timestamp('createdAt').notNull().defaultNow(),
 });
 

--- a/packages/core/dto.ts
+++ b/packages/core/dto.ts
@@ -77,6 +77,18 @@ export interface ChatAbortArgs {
     streamChannel: string;
 }
 
+export interface ChatMessageSyncInput {
+    chatId: string;
+    sequence: number;
+    messages: UIMessage[];
+}
+
+export interface ChatMessageSyncAck {
+    chatId: string;
+    sequence: number;
+    accepted: boolean;
+}
+
 // MCP Server Transport Configurations
 export interface SseTransportConfig {
     url: string;

--- a/packages/core/repositories/MessageRepository.test.ts
+++ b/packages/core/repositories/MessageRepository.test.ts
@@ -3,6 +3,7 @@ import { eq } from 'drizzle-orm';
 import { chat, message } from '../database/schema/schema';
 import type { DatabaseManager } from '../database/DatabaseManager';
 import type { NewMessage } from '../dto';
+import type { UIMessage } from 'ai';
 import { createTestDb, type TestDb } from '../test-utils/testDb';
 import { MessageRepository } from './MessageRepository';
 
@@ -110,5 +111,52 @@ describe('MessageRepository', () => {
         expect(new Date(updatedChat.lastMessageAt as unknown as Date).toISOString()).toBe(
             '2024-01-01T00:00:10.000Z',
         );
+    });
+
+    it('syncs serialized UI messages and rejects stale snapshots', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+        await testDb.db.update(chat).set({ title: 'New Chat' }).where(eq(chat.id, chatId));
+
+        const uiMessages: UIMessage[] = [
+            {
+                id: 'client-user',
+                role: 'user',
+                parts: [{ type: 'text', text: 'hello from redux' }],
+            },
+            {
+                id: 'client-assistant',
+                role: 'assistant',
+                parts: [
+                    { type: 'reasoning', text: 'thinking' },
+                    { type: 'text', text: 'assistant answer' },
+                ],
+                metadata: { modelId: 'provider:model' },
+            },
+        ];
+
+        await expect(repository.syncForChat({ chatId, sequence: 1, messages: uiMessages })).resolves.toEqual({
+            chatId,
+            sequence: 1,
+            accepted: true,
+        });
+
+        const syncedMessages = await repository.getMessagesByChatId(chatId);
+        expect(syncedMessages).toHaveLength(2);
+        expect(syncedMessages[0].uiMessage).toEqual(uiMessages[0]);
+        expect(syncedMessages[1].uiMessage).toEqual(uiMessages[1]);
+        expect(syncedMessages[1].modelIdentifier).toBe('provider:model');
+
+        const [updatedChat] = await testDb.db.select().from(chat).where(eq(chat.id, chatId)).limit(1);
+        expect(updatedChat.syncVersion).toBe(1);
+        expect(updatedChat.title).toBe('hello from redux');
+        expect(updatedChat.lastMessage).toBe('assistant answer');
+
+        await expect(repository.syncForChat({ chatId, sequence: 1, messages: [] })).resolves.toEqual({
+            chatId,
+            sequence: 1,
+            accepted: false,
+        });
+        await expect(repository.getMessagesByChatId(chatId)).resolves.toHaveLength(2);
     });
 });

--- a/packages/core/repositories/MessageRepository.ts
+++ b/packages/core/repositories/MessageRepository.ts
@@ -2,8 +2,27 @@ import { inject, injectable } from 'inversify';
 import { asc, eq } from 'drizzle-orm';
 import { CORETYPES } from '../types/types';
 import { DatabaseManager } from '../database/DatabaseManager';
-import { Message, NewMessage } from '../dto';
+import { ChatMessageSyncAck, ChatMessageSyncInput, Message, NewMessage } from '../dto';
 import { chat, message } from '../database/schema/chatSchema';
+import type { UIMessage } from 'ai';
+
+type MessageMetadata = { modelId?: string };
+
+const getPartText = (uiMessage: UIMessage, partType: string): string | null => {
+    const textParts: string[] = [];
+    for (const part of uiMessage.parts) {
+        if (part.type === partType && 'text' in part && typeof part.text === 'string') {
+            textParts.push(part.text);
+        }
+    }
+    const text = textParts.join('\n');
+    return text.length > 0 ? text : null;
+};
+
+const getModelIdentifier = (uiMessage: UIMessage): string | null => {
+    const metadata = uiMessage.metadata as MessageMetadata | undefined;
+    return metadata?.modelId ?? null;
+};
 
 @injectable()
 export class MessageRepository {
@@ -15,6 +34,66 @@ export class MessageRepository {
 
     public async getMessagesByChatId(chatId: string): Promise<Message[]> {
         return this.db.select().from(message).where(eq(message.chatId, chatId)).orderBy(asc(message.createdAt));
+    }
+
+    public async syncForChat(input: ChatMessageSyncInput): Promise<ChatMessageSyncAck> {
+        return this.db.transaction(async (tx) => {
+            const [currentChat] = await tx.select().from(chat).where(eq(chat.id, input.chatId)).limit(1);
+            if (!currentChat) {
+                throw new Error(`Chat ${input.chatId} not found`);
+            }
+
+            if ((currentChat.syncVersion ?? 0) >= input.sequence) {
+                return {
+                    chatId: input.chatId,
+                    sequence: input.sequence,
+                    accepted: false,
+                };
+            }
+
+            const now = new Date();
+            await tx.delete(message).where(eq(message.chatId, input.chatId));
+
+            if (input.messages.length > 0) {
+                await tx.insert(message).values(
+                    input.messages.map((uiMessage, index) => ({
+                        chatId: input.chatId,
+                        role: uiMessage.role,
+                        text: getPartText(uiMessage, 'text'),
+                        reasoning: getPartText(uiMessage, 'reasoning'),
+                        modelIdentifier: getModelIdentifier(uiMessage),
+                        uiMessageId: uiMessage.id,
+                        uiMessage,
+                        createdAt: new Date(now.getTime() + index),
+                    })),
+                );
+            }
+
+            const firstUserMessage = input.messages.find((uiMessage) => uiMessage.role === 'user');
+            const firstUserText = firstUserMessage ? getPartText(firstUserMessage, 'text') : null;
+            const lastMessage = input.messages[input.messages.length - 1];
+            const lastText = lastMessage ? getPartText(lastMessage, 'text') : null;
+            const chatUpdate: Partial<typeof chat.$inferInsert> = {
+                syncVersion: input.sequence,
+                lastMessageAt: now,
+            };
+
+            if (lastText) {
+                chatUpdate.lastMessage = lastText.slice(0, 200);
+            }
+
+            if (input.messages.length > 0 && firstUserText && currentChat.title === 'New Chat') {
+                chatUpdate.title = firstUserText.slice(0, 50);
+            }
+
+            await tx.update(chat).set(chatUpdate).where(eq(chat.id, input.chatId));
+
+            return {
+                chatId: input.chatId,
+                sequence: input.sequence,
+                accepted: true,
+            };
+        });
     }
 
     public async create(newMessage: NewMessage): Promise<Message> {

--- a/packages/core/services/MessageService.test.ts
+++ b/packages/core/services/MessageService.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { Message, NewMessage } from '../dto';
+import type { ChatMessageSyncInput, Message, NewMessage } from '../dto';
+import type { UIMessage } from 'ai';
 import type { MessageRepository } from '../repositories/MessageRepository';
 import { MessageService } from './MessageService';
 
@@ -10,6 +11,7 @@ describe('MessageService', () => {
     beforeEach(() => {
         repository = {
             getMessagesByChatId: vi.fn(),
+            syncForChat: vi.fn(),
             create: vi.fn(),
             update: vi.fn(),
             delete: vi.fn(),
@@ -79,6 +81,27 @@ describe('MessageService', () => {
         ]);
     });
 
+    it('returns serialized UI messages when present', async () => {
+        const uiMessage: UIMessage = {
+            id: 'client-id',
+            role: 'assistant',
+            parts: [{ type: 'text', text: 'serialized' }],
+        };
+        (repository.getMessagesByChatId as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+            {
+                id: 'db-id',
+                chatId: 'c',
+                role: 'assistant',
+                text: 'legacy text',
+                reasoning: null,
+                uiMessage,
+                createdAt: new Date(),
+            } as unknown as Message,
+        ]);
+
+        await expect(service.getMessagesByChatId('c')).resolves.toEqual([uiMessage]);
+    });
+
     it('delegates create/update/delete to the repository', async () => {
         const created = { id: 'm' } as unknown as Message;
         const updated = { id: 'm' } as unknown as Message;
@@ -100,5 +123,18 @@ describe('MessageService', () => {
 
         await service.deleteMessage('m');
         expect(repository.delete).toHaveBeenCalledWith('m');
+    });
+
+    it('delegates chat message sync to the repository', async () => {
+        const input: ChatMessageSyncInput = {
+            chatId: '00000000-0000-4000-8000-000000000001',
+            sequence: 1,
+            messages: [],
+        };
+        const ack = { chatId: input.chatId, sequence: 1, accepted: true };
+        (repository.syncForChat as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(ack);
+
+        await expect(service.syncForChat(input)).resolves.toEqual(ack);
+        expect(repository.syncForChat).toHaveBeenCalledWith(input);
     });
 });

--- a/packages/core/services/MessageService.ts
+++ b/packages/core/services/MessageService.ts
@@ -1,7 +1,7 @@
 import { inject, injectable } from 'inversify';
 import { CORETYPES } from '../types/types';
 import { MessageRepository } from '../repositories/MessageRepository';
-import { Message, NewMessage } from '../dto';
+import { ChatMessageSyncAck, ChatMessageSyncInput, Message, NewMessage } from '../dto';
 import { UIMessage } from 'ai';
 
 @injectable()
@@ -15,6 +15,10 @@ export class MessageService {
 
     private convertToUiMessage(messages: Message[]) {
         return messages.map((message) => {
+            if (message.uiMessage) {
+                return message.uiMessage;
+            }
+
             const parts: { type: 'text' | 'reasoning'; text: string }[] = [];
 
             if (message.text) {
@@ -34,6 +38,10 @@ export class MessageService {
 
             return metadata ? { ...base, metadata } : base;
         });
+    }
+
+    public async syncForChat(input: ChatMessageSyncInput): Promise<ChatMessageSyncAck> {
+        return this.messageRepository.syncForChat(input);
     }
 
     public async createMessage(newMessage: NewMessage): Promise<Message> {

--- a/src/main/controllers/ChatController.ts
+++ b/src/main/controllers/ChatController.ts
@@ -65,7 +65,7 @@ export class ChatController implements Controller {
 
     @IpcHandler('updateSelectedPersonaForChat')
     public async updateSelectedPersonaForChat(id: string, personaIdentifier: PersonaIdentifier): Promise<void> {
-        const parsedPersonaIdentifier = personaIdentifierSchema.parse(personaIdentifier);
+        const parsedPersonaIdentifier = personaIdentifierSchema.parse(personaIdentifier) as PersonaIdentifier;
         return this.chatService.updateSelectedPersonaForChat(id, parsedPersonaIdentifier);
     }
 

--- a/src/main/controllers/MessageController.test.ts
+++ b/src/main/controllers/MessageController.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { Message, NewMessage } from 'core/dto';
+import type { ChatMessageSyncInput, Message, NewMessage } from 'core/dto';
 import type { UIMessage } from 'ai';
 import type { MessageService } from 'core/services/MessageService';
 import { MessageController } from './MessageController';
@@ -12,6 +12,9 @@ describe('MessageController', () => {
 
         const service = {
             getMessagesByChatId: vi.fn().mockResolvedValue(uiMessages),
+            syncForChat: vi
+                .fn()
+                .mockResolvedValue({ chatId: '00000000-0000-4000-8000-000000000001', sequence: 1, accepted: true }),
             createMessage: vi.fn().mockResolvedValue(created),
             updateMessage: vi.fn().mockResolvedValue(updated),
             deleteMessage: vi.fn().mockResolvedValue(undefined),
@@ -21,6 +24,18 @@ describe('MessageController', () => {
 
         await expect(controller.getByChat('c')).resolves.toEqual(uiMessages);
         expect(service.getMessagesByChatId).toHaveBeenCalledWith('c');
+
+        const syncInput: ChatMessageSyncInput = {
+            chatId: '00000000-0000-4000-8000-000000000001',
+            sequence: 1,
+            messages: [{ id: 'm', role: 'user', parts: [] } as UIMessage],
+        };
+        await expect(controller.syncForChat(syncInput)).resolves.toEqual({
+            chatId: syncInput.chatId,
+            sequence: 1,
+            accepted: true,
+        });
+        expect(service.syncForChat).toHaveBeenCalledWith(syncInput);
 
         const newMessage: NewMessage = {
             chatId: 'c',

--- a/src/main/controllers/MessageController.ts
+++ b/src/main/controllers/MessageController.ts
@@ -1,9 +1,33 @@
 import { inject, injectable } from 'inversify';
 import { CORETYPES } from '../../../packages/core/types/types';
 import { MessageService } from '../../../packages/core/services/MessageService';
-import { Message, NewMessage } from '../../../packages/core/dto';
+import { ChatMessageSyncAck, ChatMessageSyncInput, Message, NewMessage } from '../../../packages/core/dto';
 import { IpcController, IpcHandler } from '../ipc/Decorators';
 import { UIMessage } from 'ai';
+import { z } from 'zod';
+
+const uiMessagePartSchema = z
+    .object({
+        type: z.string().min(1),
+    })
+    .passthrough();
+
+const uiMessageSchema = z
+    .object({
+        id: z.string().min(1),
+        role: z.enum(['system', 'user', 'assistant']),
+        parts: z.array(uiMessagePartSchema),
+        metadata: z.unknown().optional(),
+    })
+    .strict();
+
+const chatMessageSyncSchema = z
+    .object({
+        chatId: z.uuid(),
+        sequence: z.number().int().positive(),
+        messages: z.array(uiMessageSchema),
+    })
+    .strict();
 
 @injectable()
 @IpcController('message')
@@ -13,6 +37,11 @@ export class MessageController {
     @IpcHandler('getByChat')
     public async getByChat(chatId: string): Promise<UIMessage[]> {
         return this.messageService.getMessagesByChatId(chatId);
+    }
+
+    @IpcHandler('syncForChat')
+    public async syncForChat(input: ChatMessageSyncInput): Promise<ChatMessageSyncAck> {
+        return this.messageService.syncForChat(chatMessageSyncSchema.parse(input) as ChatMessageSyncInput);
     }
 
     @IpcHandler('save')

--- a/src/main/controllers/StreamingChatController.test.ts
+++ b/src/main/controllers/StreamingChatController.test.ts
@@ -108,7 +108,7 @@ describe('StreamingChatController', () => {
         expect(logger.info).toHaveBeenCalledWith('Aborted stream for channel: chan');
     });
 
-    it('streams chunks, persists messages, and emits end event on finish', async () => {
+    it('streams chunks without direct message persistence and emits end event on finish', async () => {
         const registry = { languageModel: vi.fn(() => 'lm') };
         const modelProviderService = {
             getModelProviderRegistry: vi.fn().mockResolvedValue(registry),
@@ -169,20 +169,7 @@ describe('StreamingChatController', () => {
         expect(streamOptions.experimental_transform).toBe('transform');
         expect(streamOptions.messages[0]).toEqual({ role: 'system', content: 'persona-details' });
 
-        expect(messageService.createMessage).toHaveBeenCalledWith({
-            chatId: 'chat-id',
-            role: 'user',
-            text: 'Hello',
-            reasoning: 'Think',
-            modelIdentifier: 'provider:model',
-        });
-        expect(messageService.createMessage).toHaveBeenCalledWith({
-            chatId: 'chat-id',
-            role: 'assistant',
-            text: 'assistant',
-            reasoning: 'reasoning',
-            modelIdentifier: 'provider:model',
-        });
+        expect(messageService.createMessage).not.toHaveBeenCalled();
 
         expect(webContents.send).toHaveBeenCalledWith('chan-data', {
             type: 'message-metadata',
@@ -197,14 +184,13 @@ describe('StreamingChatController', () => {
         ).toBe(false);
     });
 
-    it('emits an error when persisting the assistant message fails on finish', async () => {
+    it('does not use message persistence on finish', async () => {
         const registry = { languageModel: vi.fn(() => 'lm') };
         const modelProviderService = {
             getModelProviderRegistry: vi.fn().mockResolvedValue(registry),
         } as unknown as ModelProviderService;
-        const assistantPersistError = new Error('persist failed');
         const messageService = {
-            createMessage: vi.fn().mockResolvedValueOnce(undefined).mockRejectedValueOnce(assistantPersistError),
+            createMessage: vi.fn().mockRejectedValue(new Error('persist failed')),
         } as unknown as MessageService;
         const personaService = {
             getById: vi.fn().mockResolvedValue(undefined),
@@ -244,24 +230,23 @@ describe('StreamingChatController', () => {
             event,
         );
 
-        expect(logger.error).toHaveBeenCalledWith(
+        expect(messageService.createMessage).not.toHaveBeenCalled();
+        expect(logger.error).not.toHaveBeenCalledWith(
             'Failed to persist assistant message after streaming:',
-            assistantPersistError,
+            expect.anything(),
         );
-        expect(webContents.send).toHaveBeenCalledWith('chan-error', assistantPersistError);
-        expect(webContents.send).not.toHaveBeenCalledWith('chan-end');
+        expect(webContents.send).toHaveBeenCalledWith('chan-end');
         expect(
             (controller as unknown as { activeStreams: Map<string, AbortController> }).activeStreams.has('chan'),
         ).toBe(false);
     });
 
-    it('emits an error and skips stream startup when persisting the user message fails', async () => {
+    it('starts streaming without persisting the user message first', async () => {
         const modelProviderService = {
             getModelProviderRegistry: vi.fn().mockResolvedValue({ languageModel: vi.fn(() => 'lm') }),
         } as unknown as ModelProviderService;
-        const userPersistError = new Error('save failed');
         const messageService = {
-            createMessage: vi.fn().mockRejectedValue(userPersistError),
+            createMessage: vi.fn().mockRejectedValue(new Error('save failed')),
         } as unknown as MessageService;
         const personaService = {
             getById: vi.fn().mockResolvedValue(undefined),
@@ -295,9 +280,12 @@ describe('StreamingChatController', () => {
             event,
         );
 
-        expect(logger.error).toHaveBeenCalledWith('Failed to persist user message before streaming:', userPersistError);
-        expect(webContents.send).toHaveBeenCalledWith('chan-error', userPersistError);
-        expect(ai.streamText).not.toHaveBeenCalled();
+        expect(messageService.createMessage).not.toHaveBeenCalled();
+        expect(logger.error).not.toHaveBeenCalledWith(
+            'Failed to persist user message before streaming:',
+            expect.anything(),
+        );
+        expect(ai.streamText).toHaveBeenCalled();
         expect(
             (controller as unknown as { activeStreams: Map<string, AbortController> }).activeStreams.has('chan'),
         ).toBe(false);

--- a/src/main/controllers/StreamingChatController.ts
+++ b/src/main/controllers/StreamingChatController.ts
@@ -21,7 +21,7 @@ export class StreamingChatController implements Controller {
         @inject(CORETYPES.ModelProviderService)
         private modelProviderService: ModelProviderService,
         @inject(CORETYPES.MessageService)
-        private messageService: MessageService,
+        _messageService: MessageService,
         @inject(CORETYPES.PersonaService)
         private personaService: PersonaService,
         @inject(CORETYPES.McpClientManager)
@@ -47,9 +47,6 @@ export class StreamingChatController implements Controller {
 
         const controller = new AbortController();
         this.activeStreams.set(args.streamChannel, controller);
-        const lastUserMsg = args.messages[args.messages.length - 1];
-        const txtMsg = lastUserMsg.parts.find((part) => part.type === 'text')?.text;
-        const rsnMsg = lastUserMsg.parts.find((part) => part.type === 'reasoning')?.text;
 
         // Validate modelIdentifier before proceeding
         if (!args.modelIdentifier) {
@@ -57,23 +54,6 @@ export class StreamingChatController implements Controller {
             logger.error(errorMsg, args);
             if (!webContents.isDestroyed()) {
                 webContents.send(`${args.streamChannel}-error`, { message: errorMsg });
-            }
-            return;
-        }
-
-        try {
-            await this.messageService.createMessage({
-                chatId: args.chatId,
-                role: lastUserMsg.role,
-                text: txtMsg ?? null,
-                reasoning: rsnMsg ?? null,
-                modelIdentifier: args.modelIdentifier,
-            });
-        } catch (error) {
-            logger.error('Failed to persist user message before streaming:', error);
-            this.activeStreams.delete(args.streamChannel);
-            if (!webContents.isDestroyed()) {
-                webContents.send(`${args.streamChannel}-error`, error);
             }
             return;
         }
@@ -87,27 +67,11 @@ export class StreamingChatController implements Controller {
                 stopWhen: stepCountIs(10),
                 abortSignal: controller.signal,
                 experimental_transform: smoothStream({ delayInMs: 30 }),
-                onFinish: async (result) => {
-                    try {
-                        await this.messageService.createMessage({
-                            chatId: args.chatId,
-                            role: 'assistant',
-                            text: result.text ?? null,
-                            reasoning: result.reasoningText ?? null,
-                            modelIdentifier: args.modelIdentifier,
-                        });
-
-                        if (!webContents.isDestroyed()) {
-                            webContents.send(`${args.streamChannel}-end`);
-                        }
-                    } catch (error) {
-                        logger.error('Failed to persist assistant message after streaming:', error);
-                        if (!webContents.isDestroyed()) {
-                            webContents.send(`${args.streamChannel}-error`, error);
-                        }
-                    } finally {
-                        this.activeStreams.delete(args.streamChannel);
+                onFinish: () => {
+                    if (!webContents.isDestroyed()) {
+                        webContents.send(`${args.streamChannel}-end`);
                     }
+                    this.activeStreams.delete(args.streamChannel);
                 },
                 onAbort: () => {
                     this.activeStreams.delete(args.streamChannel);

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -18,6 +18,8 @@ import {
     McpServer,
     McpServerCreateInput,
     McpServerUpdateInput,
+    ChatMessageSyncInput,
+    ChatMessageSyncAck,
     CommandCreateInput,
     CommandDefinition,
     CommandExecution,
@@ -53,6 +55,7 @@ export interface ModelProviderApi {
 
 export interface MessageApi {
     getByChat(chatId: string): Promise<UIMessage[]>;
+    syncForChat(input: ChatMessageSyncInput): Promise<ChatMessageSyncAck>;
     save(newMessage: NewMessage): Promise<Message>;
     update(id: string, updates: Partial<NewMessage>): Promise<void>;
     delete(id: string): Promise<void>;
@@ -111,88 +114,82 @@ export interface Api {
 }
 
 export const api: Api = {
-    chat: {
-        getAllChats: (searchQuery: string | null) => ipcRenderer.invoke('chat:getAllChats', searchQuery),
-        getChatById: (id: string) => ipcRenderer.invoke('chat:getChatById', id),
-        createChat: (newChat: NewChat) => ipcRenderer.invoke('chat:createChat', newChat),
-        updateChat: (id: string, updates: Partial<NewChat>) => ipcRenderer.invoke('chat:updateChat', id, updates),
-        deleteChat: (id: string) => ipcRenderer.invoke('chat:deleteChat', id),
-        updatePinnedStatusForChat: (id: string, pinned: boolean) =>
-            ipcRenderer.invoke('chat:updatePinnedStatusForChat', id, pinned),
-        getSelectedModelForChat: (id: string) => ipcRenderer.invoke('chat:getSelectedModelForChat', id),
-        updateSelectedModelForChat: (id: string, modelIdentifier: ModelIdentifier) =>
-            ipcRenderer.invoke('chat:updateSelectedModelForChat', id, modelIdentifier),
-        updateSelectedPersonaForChat: (id: string, personaIdentifier: PersonaIdentifier) =>
-            ipcRenderer.invoke('chat:updateSelectedPersonaForChat', id, personaIdentifier),
-        updateSelectedChat: (id: string) => ipcRenderer.invoke('chat:updateSelectedChat', id),
+  chat: {
+    getAllChats: (searchQuery: string | null) => ipcRenderer.invoke('chat:getAllChats', searchQuery),
+    getChatById: (id: string) => ipcRenderer.invoke('chat:getChatById', id),
+    createChat: (newChat: NewChat) => ipcRenderer.invoke('chat:createChat', newChat),
+    updateChat: (id: string, updates: Partial<NewChat>) => ipcRenderer.invoke('chat:updateChat', id, updates),
+    deleteChat: (id: string) => ipcRenderer.invoke('chat:deleteChat', id),
+    updatePinnedStatusForChat: (id: string, pinned: boolean) => ipcRenderer.invoke('chat:updatePinnedStatusForChat', id, pinned),
+    getSelectedModelForChat: (id: string) => ipcRenderer.invoke('chat:getSelectedModelForChat', id),
+    updateSelectedModelForChat: (id: string, modelIdentifier: ModelIdentifier) => ipcRenderer.invoke('chat:updateSelectedModelForChat', id, modelIdentifier),
+    updateSelectedPersonaForChat: (id: string, personaIdentifier: PersonaIdentifier) => ipcRenderer.invoke('chat:updateSelectedPersonaForChat', id, personaIdentifier),
+    updateSelectedChat: (id: string) => ipcRenderer.invoke('chat:updateSelectedChat', id)
+  },
+  modelProvider: {
+    addProvider: (providerData: ModelProviderCreateInput, models: NewModel[]) => ipcRenderer.invoke('modelProvider:addProvider', providerData, models),
+    getProviderForId: (providerId: string) => ipcRenderer.invoke('modelProvider:getProviderForId', providerId),
+    getProviders: () => ipcRenderer.invoke('modelProvider:getProviders'),
+    getProvidersWithModels: () => ipcRenderer.invoke('modelProvider:getProvidersWithModels'),
+    deleteProvider: (providerId: string) => ipcRenderer.invoke('modelProvider:deleteProvider', providerId),
+    updateProvider: (providerId: string, updateObject: Partial<ModelProviderCreateInput>, modelsData: NewModel[]) => ipcRenderer.invoke('modelProvider:updateProvider', providerId, updateObject, modelsData),
+    getAvailableModelsFromProviders: (provider: ModelProviderCreateInput) => ipcRenderer.invoke('modelProvider:getAvailableModelsFromProviders', provider)
+  },
+  message: {
+    getByChat: (chatId: string) => ipcRenderer.invoke('message:getByChat', chatId),
+    syncForChat: (input: ChatMessageSyncInput) => ipcRenderer.invoke('message:syncForChat', input),
+    save: (newMessage: NewMessage) => ipcRenderer.invoke('message:save', newMessage),
+    update: (id: string, updates: Partial<NewMessage>) => ipcRenderer.invoke('message:update', id, updates),
+    delete: (id: string) => ipcRenderer.invoke('message:delete', id)
+  },
+  persona: {
+    getAll: () => ipcRenderer.invoke('persona:getAll'),
+    getById: (id: string) => ipcRenderer.invoke('persona:getById', id),
+    getByName: (name: string) => ipcRenderer.invoke('persona:getByName', name),
+    create: (newPersona: NewPersona) => ipcRenderer.invoke('persona:create', newPersona),
+    update: (id: string, updates: Partial<NewPersona>) => ipcRenderer.invoke('persona:update', id, updates),
+    delete: (id: string) => ipcRenderer.invoke('persona:delete', id)
+  },
+  command: {
+    listAll: () => ipcRenderer.invoke('command:listAll'),
+    create: (input: CommandCreateInput) => ipcRenderer.invoke('command:create', input),
+    update: (id: string, updates: CommandUpdateInput) => ipcRenderer.invoke('command:update', id, updates),
+    delete: (id: string) => ipcRenderer.invoke('command:delete', id),
+    execute: (input: { input: string }) => ipcRenderer.invoke('command:execute', input)
+  },
+  mcpServer: {
+    getAll: () => ipcRenderer.invoke('mcpServer:getAll'),
+    getAllEnabled: () => ipcRenderer.invoke('mcpServer:getAllEnabled'),
+    getById: (id: string) => ipcRenderer.invoke('mcpServer:getById', id),
+    getByName: (name: string) => ipcRenderer.invoke('mcpServer:getByName', name),
+    create: (data: McpServerCreateInput) => ipcRenderer.invoke('mcpServer:create', data),
+    update: (id: string, updates: McpServerUpdateInput) => ipcRenderer.invoke('mcpServer:update', id, updates),
+    delete: (id: string) => ipcRenderer.invoke('mcpServer:delete', id),
+    enable: (id: string) => ipcRenderer.invoke('mcpServer:enable', id),
+    disable: (id: string) => ipcRenderer.invoke('mcpServer:disable', id),
+    refreshClient: (id: string) => ipcRenderer.invoke('mcpServer:refreshClient', id),
+    getClientCount: () => ipcRenderer.invoke('mcpServer:getClientCount'),
+    getServerTools: (id: string) => ipcRenderer.invoke('mcpServer:getServerTools', id),
+    updateToolApproval: (serverId: string, toolName: string, needsApproval: boolean) => ipcRenderer.invoke('mcpServer:updateToolApproval', serverId, toolName, needsApproval)
+  },
+  streaming: {
+    sendMessage: (args: ChatSendMessageArgs) => ipcRenderer.send('streamingChat:sendMessage', args),
+    abortMessage: (args: ChatAbortArgs) => ipcRenderer.send('streamingChat:abortMessage', args),
+    onData: (channel: string, listener: (data: UIMessageChunk) => void) => {
+      const subscription = (_event: unknown, data: UIMessageChunk) => listener(data);
+      ipcRenderer.on(`${channel}-data`, subscription);
     },
-    modelProvider: {
-        addProvider: (providerData: ModelProviderCreateInput, models: NewModel[]) =>
-            ipcRenderer.invoke('modelProvider:addProvider', providerData, models),
-        getProviderForId: (providerId: string) => ipcRenderer.invoke('modelProvider:getProviderForId', providerId),
-        getProviders: () => ipcRenderer.invoke('modelProvider:getProviders'),
-        getProvidersWithModels: () => ipcRenderer.invoke('modelProvider:getProvidersWithModels'),
-        deleteProvider: (providerId: string) => ipcRenderer.invoke('modelProvider:deleteProvider', providerId),
-        updateProvider: (providerId: string, updateObject: Partial<ModelProviderCreateInput>, modelsData: NewModel[]) =>
-            ipcRenderer.invoke('modelProvider:updateProvider', providerId, updateObject, modelsData),
-        getAvailableModelsFromProviders: (provider: ModelProviderCreateInput) =>
-            ipcRenderer.invoke('modelProvider:getAvailableModelsFromProviders', provider),
+    onEnd: (channel: string, listener: () => void) => {
+      ipcRenderer.on(`${channel}-end`, listener);
     },
-    message: {
-        getByChat: (chatId: string) => ipcRenderer.invoke('message:getByChat', chatId),
-        save: (newMessage: NewMessage) => ipcRenderer.invoke('message:save', newMessage),
-        update: (id: string, updates: Partial<NewMessage>) => ipcRenderer.invoke('message:update', id, updates),
-        delete: (id: string) => ipcRenderer.invoke('message:delete', id),
+    onError: (channel: string, listener: (error: unknown) => void) => {
+      const subscription = (_event: unknown, error: unknown) => listener(error);
+      ipcRenderer.on(`${channel}-error`, subscription);
     },
-    persona: {
-        getAll: () => ipcRenderer.invoke('persona:getAll'),
-        getById: (id: string) => ipcRenderer.invoke('persona:getById', id),
-        getByName: (name: string) => ipcRenderer.invoke('persona:getByName', name),
-        create: (newPersona: NewPersona) => ipcRenderer.invoke('persona:create', newPersona),
-        update: (id: string, updates: Partial<NewPersona>) => ipcRenderer.invoke('persona:update', id, updates),
-        delete: (id: string) => ipcRenderer.invoke('persona:delete', id),
+    removeListeners: (channel: string) => {
+      ipcRenderer.removeAllListeners(`${channel}-error`);
+      ipcRenderer.removeAllListeners(`${channel}-end`);
+      ipcRenderer.removeAllListeners(`${channel}-data`);
     },
-    command: {
-        listAll: () => ipcRenderer.invoke('command:listAll'),
-        create: (input: CommandCreateInput) => ipcRenderer.invoke('command:create', input),
-        update: (id: string, updates: CommandUpdateInput) => ipcRenderer.invoke('command:update', id, updates),
-        delete: (id: string) => ipcRenderer.invoke('command:delete', id),
-        execute: (input: { input: string }) => ipcRenderer.invoke('command:execute', input),
-    },
-    mcpServer: {
-        getAll: () => ipcRenderer.invoke('mcpServer:getAll'),
-        getAllEnabled: () => ipcRenderer.invoke('mcpServer:getAllEnabled'),
-        getById: (id: string) => ipcRenderer.invoke('mcpServer:getById', id),
-        getByName: (name: string) => ipcRenderer.invoke('mcpServer:getByName', name),
-        create: (data: McpServerCreateInput) => ipcRenderer.invoke('mcpServer:create', data),
-        update: (id: string, updates: McpServerUpdateInput) => ipcRenderer.invoke('mcpServer:update', id, updates),
-        delete: (id: string) => ipcRenderer.invoke('mcpServer:delete', id),
-        enable: (id: string) => ipcRenderer.invoke('mcpServer:enable', id),
-        disable: (id: string) => ipcRenderer.invoke('mcpServer:disable', id),
-        refreshClient: (id: string) => ipcRenderer.invoke('mcpServer:refreshClient', id),
-        getClientCount: () => ipcRenderer.invoke('mcpServer:getClientCount'),
-        getServerTools: (id: string) => ipcRenderer.invoke('mcpServer:getServerTools', id),
-        updateToolApproval: (serverId: string, toolName: string, needsApproval: boolean) =>
-            ipcRenderer.invoke('mcpServer:updateToolApproval', serverId, toolName, needsApproval),
-    },
-    streaming: {
-        sendMessage: (args: ChatSendMessageArgs) => ipcRenderer.send('streamingChat:sendMessage', args),
-        abortMessage: (args: ChatAbortArgs) => ipcRenderer.send('streamingChat:abortMessage', args),
-        onData: (channel: string, listener: (data: UIMessageChunk) => void) => {
-            const subscription = (_event: unknown, data: UIMessageChunk) => listener(data);
-            ipcRenderer.on(`${channel}-data`, subscription);
-        },
-        onEnd: (channel: string, listener: () => void) => {
-            ipcRenderer.on(`${channel}-end`, listener);
-        },
-        onError: (channel: string, listener: (error: unknown) => void) => {
-            const subscription = (_event: unknown, error: unknown) => listener(error);
-            ipcRenderer.on(`${channel}-error`, subscription);
-        },
-        removeListeners: (channel: string) => {
-            ipcRenderer.removeAllListeners(`${channel}-error`);
-            ipcRenderer.removeAllListeners(`${channel}-end`);
-            ipcRenderer.removeAllListeners(`${channel}-data`);
-        },
-    },
+  },
 };

--- a/src/renderer/AGENTS.override.md
+++ b/src/renderer/AGENTS.override.md
@@ -67,11 +67,16 @@ Apply the highest-impact rules first:
 ## Data flow conventions
 
 - Prefer a single “source of truth” for cached UI state.
+- Chat page state is Redux-owned:
+    - Use `src/renderer/src/store/chat-slice.ts` thunks/selectors for chat history, selected chat, message state, draft state, model/persona/catalog loading, and search state.
+    - Keep AI SDK `Chat` instances in `src/renderer/src/store/chat-runtime-registry.ts` so route changes do not interrupt active streams.
+    - Do not reintroduce `useChat` directly in `src/renderer/src/app/(main)/page.tsx`.
 - Keep renderer logic focused on presentation + orchestration:
     - DB queries, encryption, provider registries belong in `packages/core` and/or main controllers.
 - For streaming chat:
-    - Renderer uses `@ai-sdk/react` + `IpcChatTransport` (`src/renderer/src/chat-transport.ts`).
+    - Renderer uses AI SDK `Chat` + `IpcChatTransport` (`src/renderer/src/chat-transport.ts`) through the runtime registry.
     - Ensure stream channels are stable (`chat-stream-${chatId}`) and all listeners are cleaned up.
+    - Persist every runtime message update through the ordered `message:syncForChat` thunk/IPC path.
 
 ## Testing expectations (renderer)
 

--- a/src/renderer/package.json
+++ b/src/renderer/package.json
@@ -27,6 +27,7 @@
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@radix-ui/react-use-controllable-state": "^1.2.2",
+        "@reduxjs/toolkit": "^2.12.0",
         "@rive-app/react-webgl2": "^4.26.2",
         "@streamdown/cjk": "^1.0.1",
         "@streamdown/code": "^1.0.1",
@@ -58,6 +59,7 @@
         "react-jsx-parser": "^2.4.1",
         "react-markdown": "10.1.0",
         "react-mentions": "^4.4.10",
+        "react-redux": "^9.3.0",
         "react-syntax-highlighter": "16.1.0",
         "remark-gfm": "4.0.1",
         "shiki": "^3.22.0",
@@ -71,10 +73,10 @@
         "usehooks-ts": "3.1.1"
     },
     "devDependencies": {
+        "@eslint/eslintrc": "3.3.3",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
-        "@eslint/eslintrc": "3.3.3",
         "@types/node": "25.0.9",
         "@types/react": "19.2.8",
         "@types/react-dom": "19.2.3",

--- a/src/renderer/src/app/(main)/page.tsx
+++ b/src/renderer/src/app/(main)/page.tsx
@@ -1,274 +1,172 @@
 'use client';
-import { JSX, useCallback, useEffect, useMemo, useState } from 'react';
+
+import { JSX, useCallback, useEffect } from 'react';
 import { ChatHistory } from '@/components/chat-history';
-import { Chat } from 'core/dto';
 import { ChatHeader } from '@/components/chat-header';
 import { Messages } from '@/components/messages';
 import { MultimodalInput } from '@/components/multimodal-input';
-import { useChat } from '@ai-sdk/react';
-import { IpcChatTransport } from '@/chat-transport';
 import { Empty, EmptyContent, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '@/components/ui/empty';
 import { MessageCirclePlus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { lastAssistantMessageIsCompleteWithApprovalResponses, UIMessage } from 'ai';
-import { toast } from 'sonner';
-import { logger } from '../../../logger';
+import {
+    approveToolCall,
+    chatActions,
+    createChat,
+    deleteChat,
+    loadChatCatalog,
+    loadChats,
+    regenerateChatResponse,
+    selectChat,
+    selectChats,
+    selectSelectedChat,
+    selectSelectedMessages,
+    selectSelectedStatus,
+    sendChatMessage,
+    stopChatResponse,
+    togglePinnedChat,
+    updateSelectedModel,
+    updateSelectedPersona,
+} from '@/store/chat-slice';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
+import type { PromptInputMessage } from '@/components/ai-elements/prompt-input';
 
 export default function Page(): JSX.Element {
-    const [chatHistory, setChatHistory] = useState<Chat[]>([]);
-    const [selectedChat, setSelectedChat] = useState<Chat | null>(null);
-    const [refreshHistory, setRefreshHistory] = useState(false);
-    const [searchHistoryQuery, setSearchHistoryQuery] = useState<string | null>(null);
-    const [searchQuery, setSearchQuery] = useState('');
-    const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
-    const [totalMatches, setTotalMatches] = useState(0);
-    const transport = useMemo(() => new IpcChatTransport(), []);
-
-    const updateChatInHistory = useCallback((chatId: string, updates: Partial<Chat>) => {
-        setChatHistory((prev) => prev.map((c) => (c.id === chatId ? { ...c, ...updates } : c)));
-        setSelectedChat((prev) => (prev && prev.id === chatId ? { ...prev, ...updates } : prev));
-    }, []);
-
-    const { messages, sendMessage, status, regenerate, setMessages, addToolApprovalResponse, stop } =
-        useChat<UIMessage>({
-            id: selectedChat?.id,
-            transport,
-            sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
-            onFinish: ({ message }) => {
-                // locally update the chat history
-                if (!selectedChat) return;
-                const textPart = message.parts?.find((p) => p.type === 'text') as
-                    | { type: 'text'; text: string }
-                    | undefined;
-                const text = textPart?.text;
-                const updates: Partial<Chat> = {
-                    lastMessage: text ? text.slice(0, 200) : selectedChat.lastMessage,
-                    lastMessageAt: new Date(),
-                };
-                // Update title on first exchange (matches backend logic in MessageRepository)
-                const userMessages = messages.filter((m) => m.role === 'user');
-                if (userMessages.length === 1) {
-                    const userTextPart = userMessages[0].parts?.find((p) => p.type === 'text') as
-                        | { type: 'text'; text: string }
-                        | undefined;
-                    if (userTextPart?.text) {
-                        updates.title = userTextPart.text.slice(0, 50);
-                    }
-                }
-                updateChatInHistory(selectedChat.id, updates);
-            },
-            onError: (error) => {
-                toast.error('Failed to Stream Data', {
-                    description: error.message,
-                });
-            },
-        });
+    const dispatch = useAppDispatch();
+    const chatHistory = useAppSelector(selectChats);
+    const selectedChat = useAppSelector(selectSelectedChat);
+    const messages = useAppSelector(selectSelectedMessages);
+    const status = useAppSelector(selectSelectedStatus);
+    const searchQuery = useAppSelector((state) => state.chat.conversationSearchQuery);
+    const currentMatchIndex = useAppSelector((state) => state.chat.currentMatchIndex);
+    const totalMatches = useAppSelector((state) => state.chat.totalMatches);
+    const catalog = useAppSelector((state) => state.chat.catalog);
+    const draft = useAppSelector((state) => (selectedChat ? state.chat.draftsByChatId[selectedChat.id] ?? '' : ''));
 
     useEffect(() => {
-        let active = true;
-        window.api.chat
-            .getAllChats(searchHistoryQuery)
-            .then((chats) => {
-                if (!active) {
-                    return;
-                }
-                setChatHistory(chats);
-                if (chats.length > 0) {
-                    setSelectedChat(chats.find((chat) => chat.selected) ?? chats[0]);
-                } else {
-                    setSelectedChat(null);
-                    setMessages([]);
-                }
-                setRefreshHistory(false);
-            })
-            .catch((error) => {
-                if (!active) {
-                    return;
-                }
-                logger.error(error);
-                toast.error('Failed to load chats');
-                setRefreshHistory(false);
-            });
+        void dispatch(loadChats());
+        void dispatch(loadChatCatalog());
+    }, [dispatch]);
 
-        return () => {
-            active = false;
-        };
-    }, [refreshHistory, searchHistoryQuery, setMessages]);
+    const handleNewChat = useCallback(() => {
+        void dispatch(createChat());
+    }, [dispatch]);
 
-    useEffect(() => {
-        if (!selectedChat?.id) {
-            setMessages([]);
-            return;
-        }
+    const searchFromChatHistory = useCallback(
+        (query: string) => {
+            dispatch(chatActions.historySearchChanged(query));
+            void dispatch(loadChats());
+        },
+        [dispatch],
+    );
 
-        let active = true;
-        const chatId = selectedChat.id;
-        window.api.message
-            .getByChat(chatId)
-            .then((chat) => {
-                if (!active || selectedChat.id !== chatId) {
-                    return;
-                }
-                if (chat) {
-                    setMessages(chat);
-                }
-            })
-            .catch((error) => {
-                if (!active) {
-                    return;
-                }
-                logger.error(error);
-                toast.error('Failed to load chat messages');
-            });
+    const handleSelectChat = useCallback(
+        (chatId: string) => {
+            void dispatch(selectChat(chatId));
+        },
+        [dispatch],
+    );
 
-        return () => {
-            active = false;
-        };
-    }, [selectedChat?.id, setMessages]);
+    const handleDeleteChat = useCallback(
+        (chatId: string) => {
+            void dispatch(deleteChat(chatId));
+        },
+        [dispatch],
+    );
 
-    const handleNewChat = useCallback(async () => {
-        try {
-            await window.api.chat.createChat({ title: 'New Chat' });
-            setRefreshHistory(true);
-        } catch (error) {
-            logger.error(error);
-            toast.error('Failed to create chat');
-        }
-    }, []);
+    const handlePinChat = useCallback(
+        (chatId: string, pinned: boolean) => {
+            void dispatch(togglePinnedChat({ chatId, pinned }));
+        },
+        [dispatch],
+    );
 
-    const searchFromChatHistory = useCallback((searchQuery: string) => {
-        setSearchHistoryQuery(searchQuery);
-        setRefreshHistory(true);
-    }, []);
+    const handleSearch = useCallback(
+        (query: string) => {
+            dispatch(chatActions.conversationSearchChanged(query));
+        },
+        [dispatch],
+    );
 
-    const handleSelectChat = useCallback(async (chat: Chat) => {
-        try {
-            await window.api.chat.updateSelectedChat(chat.id);
-            setSelectedChat(chat);
-        } catch (error) {
-            logger.error(error);
-            toast.error('Failed to select chat');
-        }
-    }, []);
-
-    const handleDeleteChat = useCallback(async (chat: Chat) => {
-        try {
-            await window.api.chat.deleteChat(chat.id);
-            setRefreshHistory(true);
-        } catch (error) {
-            logger.error(error);
-            toast.error('Failed to delete chat');
-        }
-    }, []);
-
-    const handlePinChat = useCallback(async (chat: Chat) => {
-        try {
-            await window.api.chat.updatePinnedStatusForChat(chat.id, !chat.pinned);
-            setRefreshHistory(true);
-        } catch (error) {
-            logger.error(error);
-            toast.error('Failed to update chat pin status');
-        }
-    }, []);
-
-    const handleSearch = useCallback((query: string) => {
-        setSearchQuery(query);
-        if (!query) {
-            setCurrentMatchIndex(0);
-            setTotalMatches(0);
-        }
-    }, []);
-
-    const handleMatchesFound = useCallback((count: number) => {
-        setTotalMatches(count);
-        if (count > 0) {
-            setCurrentMatchIndex((prev) => {
-                if (prev === 0) return 1;
-                if (prev > count) return count;
-                return prev;
-            });
-        } else {
-            setCurrentMatchIndex(0);
-        }
-    }, []);
-
-    const handleNextMatch = useCallback(() => {
-        if (totalMatches > 0) {
-            setCurrentMatchIndex((prev) => (prev < totalMatches ? prev + 1 : 1));
-        }
-    }, [totalMatches]);
-
-    const handlePrevMatch = useCallback(() => {
-        if (totalMatches > 0) {
-            setCurrentMatchIndex((prev) => (prev > 1 ? prev - 1 : totalMatches));
-        }
-    }, [totalMatches]);
-
-    const handleClearSearch = useCallback(() => {
-        setSearchQuery('');
-        setCurrentMatchIndex(0);
-        setTotalMatches(0);
-    }, []);
+    const handleMatchesFound = useCallback(
+        (count: number) => {
+            dispatch(chatActions.matchesFound(count));
+        },
+        [dispatch],
+    );
 
     const handleModelChange = useCallback(
         (providerName: string, modelId: string) => {
             if (!selectedChat) return;
-
-            const updatedChat = {
-                ...selectedChat,
-                selectedProvider: providerName,
-                selectedModelId: modelId,
-            };
-
-            setSelectedChat(updatedChat);
-
-            // update local chat history state
-            setChatHistory((prev) => prev.map((chat) => (chat.id === selectedChat.id ? updatedChat : chat)));
-
-            window.api.chat
-                .updateSelectedModelForChat(selectedChat.id, {
-                    selectedProvider: providerName,
-                    selectedModelId: modelId,
-                })
-                .catch((error) => {
-                    logger.error(error);
-                    setRefreshHistory(true);
-                });
+            void dispatch(updateSelectedModel({ chatId: selectedChat.id, providerName, modelId }));
         },
-        [selectedChat],
+        [dispatch, selectedChat],
     );
 
     const handlePersonaChange = useCallback(
         (personaId: string | null) => {
             if (!selectedChat) return;
-
-            const updatedChat = {
-                ...selectedChat,
-                selectedPersonaId: personaId,
-            };
-
-            setSelectedChat(updatedChat);
-
-            setChatHistory((prev) => prev.map((chat) => (chat.id === selectedChat.id ? updatedChat : chat)));
-
-            window.api.chat
-                .updateSelectedPersonaForChat(selectedChat.id, {
-                    selectedPersonaId: personaId,
-                })
-                .catch((error) => {
-                    logger.error(error);
-                    setRefreshHistory(true);
-                });
+            void dispatch(updateSelectedPersona({ chatId: selectedChat.id, personaId }));
         },
-        [selectedChat],
+        [dispatch, selectedChat],
     );
+
+    const handleDraftChange = useCallback(
+        (draftText: string) => {
+            if (!selectedChat) return;
+            dispatch(chatActions.draftChanged({ chatId: selectedChat.id, draft: draftText }));
+        },
+        [dispatch, selectedChat],
+    );
+
+    const handleSendMessage = useCallback(
+        (message: PromptInputMessage) => {
+            if (!selectedChat) {
+                return Promise.resolve();
+            }
+            return dispatch(
+                sendChatMessage({
+                    chatId: selectedChat.id,
+                    text: message.text,
+                    files: message.files,
+                }),
+            ).unwrap();
+        },
+        [dispatch, selectedChat],
+    );
+
+    const handleRegenerate = useCallback(
+        (options?: { messageId?: string }) => {
+            if (!selectedChat) {
+                return Promise.resolve();
+            }
+            void dispatch(regenerateChatResponse({ chatId: selectedChat.id, messageId: options?.messageId }));
+            return Promise.resolve();
+        },
+        [dispatch, selectedChat],
+    );
+
+    const handleToolApproval = useCallback(
+        (response: { id: string; approved: boolean; reason?: string }) => {
+            if (!selectedChat) {
+                return Promise.resolve();
+            }
+            void dispatch(approveToolCall({ chatId: selectedChat.id, response }));
+            return Promise.resolve();
+        },
+        [dispatch, selectedChat],
+    );
+
+    const handleStop = useCallback(() => {
+        if (!selectedChat) return;
+        void dispatch(stopChatResponse(selectedChat.id));
+    }, [dispatch, selectedChat]);
 
     return (
         <div className="flex-1 min-h-0 flex rounded-b-lg border-t-0 overflow-hidden bg-background">
             <ChatHistory
                 chats={chatHistory}
                 selectedChat={selectedChat}
-                onChangeSelectedChat={handleSelectChat}
+                onChangeSelectedChat={(chat) => handleSelectChat(chat.id)}
                 onNewChat={handleNewChat}
                 onSearch={searchFromChatHistory}
             ></ChatHistory>
@@ -279,14 +177,14 @@ export default function Page(): JSX.Element {
                             <div className="flex-1">
                                 <ChatHeader
                                     chat={selectedChat}
-                                    onDeleteChat={handleDeleteChat}
-                                    onPinChat={handlePinChat}
+                                    onDeleteChat={(chat) => handleDeleteChat(chat.id)}
+                                    onPinChat={(chat) => handlePinChat(chat.id, chat.pinned ?? false)}
                                     onSearch={handleSearch}
                                     currentMatch={currentMatchIndex}
                                     totalMatches={totalMatches}
-                                    onNextMatch={handleNextMatch}
-                                    onPrevMatch={handlePrevMatch}
-                                    onClearSearch={handleClearSearch}
+                                    onNextMatch={() => dispatch(chatActions.nextMatch())}
+                                    onPrevMatch={() => dispatch(chatActions.previousMatch())}
+                                    onClearSearch={() => dispatch(chatActions.clearConversationSearch())}
                                 />
                             </div>
                         </div>
@@ -295,11 +193,12 @@ export default function Page(): JSX.Element {
                                 chatId={selectedChat.id}
                                 status={status}
                                 messages={messages}
-                                regenerate={regenerate}
+                                regenerate={handleRegenerate}
                                 searchQuery={searchQuery}
                                 currentMatchIndex={currentMatchIndex}
                                 onMatchesFound={handleMatchesFound}
-                                addToolApprovalResponse={addToolApprovalResponse}
+                                addToolApprovalResponse={handleToolApproval}
+                                providers={catalog.providers}
                             />
                         </div>
                         <div className="p-4 bg-background shrink-0 max-w-3xl mx-auto w-full border-t">
@@ -307,10 +206,15 @@ export default function Page(): JSX.Element {
                                 chat={selectedChat}
                                 status={status}
                                 messages={messages}
-                                sendMessage={sendMessage}
+                                draft={draft}
+                                onDraftChange={handleDraftChange}
+                                onSendMessage={handleSendMessage}
                                 onModelChange={handleModelChange}
                                 onPersonaChange={handlePersonaChange}
-                                stop={stop}
+                                stop={handleStop}
+                                providers={catalog.providers}
+                                personas={catalog.personas}
+                                commands={catalog.commands}
                             />
                         </div>
                     </>

--- a/src/renderer/src/app/layout.tsx
+++ b/src/renderer/src/app/layout.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import './globals.css';
 import { ThemeProvider } from 'next-themes';
+import { StoreProvider } from '@/store/provider';
 
 export default function RootLayout({
     children,
@@ -11,7 +12,7 @@ export default function RootLayout({
     return (
         <body>
             <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
-                {children}
+                <StoreProvider>{children}</StoreProvider>
             </ThemeProvider>
         </body>
     );

--- a/src/renderer/src/components/messages.tsx
+++ b/src/renderer/src/components/messages.tsx
@@ -1,6 +1,5 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import equal from 'fast-deep-equal';
-import type { UseChatHelpers } from '@ai-sdk/react';
 import {
     Conversation,
     ConversationContent,
@@ -18,7 +17,7 @@ import { CopyIcon, MessageSquare } from 'lucide-react';
 import { Reasoning, ReasoningContent, ReasoningTrigger } from '@/components/ai-elements/reasoning';
 import { Source, Sources, SourcesContent, SourcesTrigger } from '@/components/ai-elements/sources';
 import { Loader } from '@/components/ai-elements/loader';
-import { DynamicToolUIPart, UIMessage } from 'ai';
+import { DynamicToolUIPart, UIMessage, type ChatStatus } from 'ai';
 import { PreviewAttachment } from '@/components/preview-attachment';
 import { Tool, ToolHeader, ToolContent, ToolInput, ToolOutput } from './ai-elements/tool';
 import {
@@ -50,6 +49,12 @@ const MODEL_NAME_COLORS = [
 
 type MessageMetadata = {
     modelId?: string;
+};
+
+type ToolApprovalResponse = {
+    id: string;
+    approved: boolean;
+    reason?: string;
 };
 
 // Normalize a model identifier into provider/model parts for display.
@@ -147,7 +152,7 @@ interface ToolPartRendererProps {
     part: DynamicToolUIPart;
     messageId: string;
     partIndex: number;
-    addToolApprovalResponse?: UseChatHelpers<UIMessage>['addToolApprovalResponse'];
+    addToolApprovalResponse?: (response: ToolApprovalResponse) => Promise<void>;
 }
 
 const ToolPartRenderer = memo(function ToolPartRenderer({
@@ -211,13 +216,13 @@ const ToolPartRenderer = memo(function ToolPartRenderer({
 interface MessageItemProps {
     message: UIMessage;
     isLastMessage: boolean;
-    status: UseChatHelpers<UIMessage>['status'];
+    status: ChatStatus;
     searchQuery?: string;
     matchStartIndexMap: Record<string, number>;
     modelInfo?: { identifier: string; label: string; providerType?: ProviderWithModels['type'] };
     modelColorClass?: string;
     resolvedTheme?: string;
-    addToolApprovalResponse?: UseChatHelpers<UIMessage>['addToolApprovalResponse'];
+    addToolApprovalResponse?: (response: ToolApprovalResponse) => Promise<void>;
 }
 
 const MessageItem = memo(
@@ -400,13 +405,14 @@ const MessageItem = memo(
 
 interface MessagesProps {
     chatId: string;
-    status: UseChatHelpers<UIMessage>['status'];
+    status: ChatStatus;
     messages: UIMessage[];
-    regenerate: UseChatHelpers<UIMessage>['regenerate'];
+    regenerate: (options?: { messageId?: string }) => Promise<void>;
     searchQuery?: string;
     currentMatchIndex?: number;
     onMatchesFound?: (count: number) => void;
-    addToolApprovalResponse?: UseChatHelpers<UIMessage>['addToolApprovalResponse'];
+    addToolApprovalResponse?: (response: ToolApprovalResponse) => Promise<void>;
+    providers: ProviderWithModels[];
 }
 
 function PureMessages({
@@ -416,27 +422,10 @@ function PureMessages({
     currentMatchIndex,
     onMatchesFound,
     addToolApprovalResponse,
+    providers,
 }: MessagesProps) {
     const { resolvedTheme } = useTheme();
-    const [providers, setProviders] = useState<ProviderWithModels[]>([]);
     const prevMatchIndexRef = useRef<number | null>(null);
-
-    useEffect(() => {
-        let mounted = true;
-        window.api.modelProvider
-            .getProvidersWithModels()
-            .then((list) => {
-                if (mounted) {
-                    setProviders(list);
-                }
-            })
-            .catch((error) => {
-                console.error('Failed to load providers', error);
-            });
-        return () => {
-            mounted = false;
-        };
-    }, []);
 
     const providersByName = useMemo(() => {
         return new Map(providers.map((provider) => [provider.name, provider]));

--- a/src/renderer/src/components/multimodal-input.tsx
+++ b/src/renderer/src/components/multimodal-input.tsx
@@ -13,16 +13,13 @@ import {
     ModelSelectorTrigger,
 } from '@/components/ai-elements/model-selector';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import type { UseChatHelpers } from '@ai-sdk/react';
-import type { UIMessage } from 'ai';
+import type { ChatStatus, UIMessage } from 'ai';
 import { ModelModalityEnum } from 'core/database/schema/modelProviderSchema';
 import type { Chat, CommandDefinition, Persona, ProviderWithModels } from 'core/dto';
 import { cn } from '@/lib/utils';
 import { CheckIcon, ChevronUp, XIcon } from 'lucide-react';
 import type { FocusEvent, KeyboardEvent } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { toast } from 'sonner';
-import { logger } from '../../logger';
 import { Attachment, AttachmentPreview, AttachmentRemove, Attachments } from './ai-elements/attachments';
 import { McpToolsSelector } from './mcp-tools-selector';
 import {
@@ -45,65 +42,36 @@ import {
 } from './ai-elements/prompt-input';
 import { TokenUsageIndicator } from './token-usage-indicator';
 
-const parsePersonaDirective = (text: string) => {
-    const match = text.match(/^\s*@persona(?:\s*[:=])?\s*(?:"([^"]+)"|'([^']+)'|([^\s]+))\s*/i);
-    if (!match) {
-        return { text, personaName: undefined };
-    }
-
-    const personaName = match[1] ?? match[2] ?? match[3];
-    const remainingText = text.slice(match[0].length).trimStart();
-    return {
-        text: remainingText,
-        personaName,
-    };
-};
-
 export function MultimodalInput({
     chat,
     status,
     messages,
-    sendMessage,
+    draft,
+    onDraftChange,
+    onSendMessage,
     onModelChange,
     onPersonaChange,
     stop,
+    providers,
+    personas,
+    commands,
 }: {
     chat: Chat;
-    status: UseChatHelpers<UIMessage>['status'];
+    status: ChatStatus;
     messages: Array<UIMessage>;
-    sendMessage: UseChatHelpers<UIMessage>['sendMessage'];
+    draft: string;
+    onDraftChange: (draft: string) => void;
+    onSendMessage: (message: PromptInputMessage) => Promise<void>;
     className?: string;
     stillAnswering?: boolean;
     onModelChange: (providerName: string, modelId: string) => void;
     onPersonaChange: (personaId: string | null) => void;
-    stop?: UseChatHelpers<UIMessage>['stop'];
+    stop?: () => void;
+    providers: ProviderWithModels[];
+    personas: Persona[];
+    commands: CommandDefinition[];
 }) {
-    const [input, setInput] = useState<string>('');
-    const [providers, setProviders] = useState<ProviderWithModels[]>([]);
     const [modelSelectorOpen, setModelSelectorOpen] = useState(false);
-    const [personas, setPersonas] = useState<Persona[]>([]);
-    const [commands, setCommands] = useState<CommandDefinition[]>([]);
-
-    useEffect(() => {
-        window.api.command
-            .listAll()
-            .then((fetchedCommands) => setCommands(fetchedCommands))
-            .catch((error) => logger.error(error));
-    }, []);
-
-    useEffect(() => {
-        window.api.modelProvider
-            .getProvidersWithModels()
-            .then((fetchedProviders) => setProviders(fetchedProviders))
-            .catch((error) => logger.error(error));
-    }, []);
-
-    useEffect(() => {
-        window.api.persona
-            .getAll()
-            .then((fetchedPersonas) => setPersonas(fetchedPersonas))
-            .catch((error) => logger.error(error));
-    }, []);
 
     const selectedModelInfo = useMemo(() => {
         if (providers.length === 0) return undefined;
@@ -138,40 +106,10 @@ export function MultimodalInput({
             if (!chat.selectedModelId) {
                 return;
             }
-            const modelId = chat.selectedProvider + ':' + chat.selectedModelId;
-            const { text: cleanedText } = parsePersonaDirective(message.text);
-            let resolvedText = cleanedText;
-
-            if (cleanedText.trim().startsWith('/')) {
-                try {
-                    const result = await window.api.command.execute({
-                        input: cleanedText,
-                    });
-                    resolvedText = result.resolvedText;
-                } catch (error) {
-                    const message = error instanceof Error ? error.message : 'Failed to execute command.';
-                    toast.error(message);
-                    return;
-                }
-            }
-
-            sendMessage(
-                {
-                    text: resolvedText,
-                    files: message.files,
-                },
-                {
-                    metadata: { modelId, personaId: chat.selectedPersonaId ?? null },
-                },
-            )
-                .catch((error) => {
-                    toast.error(error.message);
-                })
-                .finally(() => {
-                    setInput('');
-                });
+            await onSendMessage(message);
+            onDraftChange('');
         },
-        [chat.selectedModelId, chat.selectedProvider, chat.selectedPersonaId, sendMessage],
+        [chat.selectedModelId, onDraftChange, onSendMessage],
     );
 
     const handlePersonaSelection = useCallback(
@@ -203,7 +141,7 @@ export function MultimodalInput({
             <PromptInputContent
                 chat={chat}
                 handlePersonaSelection={handlePersonaSelection}
-                input={input}
+                input={draft}
                 modelSelectorOpen={modelSelectorOpen}
                 onModelChange={onModelChange}
                 personaOptions={personaOptions}
@@ -211,7 +149,7 @@ export function MultimodalInput({
                 providers={providers}
                 selectedModelInfo={selectedModelInfo}
                 selectedPersonaId={chat.selectedPersonaId ?? null}
-                setInput={setInput}
+                setInput={onDraftChange}
                 setModelSelectorOpen={setModelSelectorOpen}
                 status={status}
                 submitForm={submitForm}
@@ -253,9 +191,9 @@ function PromptInputContent({
     selectedPersonaId: string | null;
     setInput: (value: string) => void;
     setModelSelectorOpen: (value: boolean) => void;
-    status: UseChatHelpers<UIMessage>['status'];
+    status: ChatStatus;
     submitForm: (message: PromptInputMessage) => Promise<void>;
-    stop?: UseChatHelpers<UIMessage>['stop'];
+    stop?: () => void;
     messages: Array<UIMessage>;
 }) {
     const attachments = usePromptInputAttachments();

--- a/src/renderer/src/store/chat-errors.ts
+++ b/src/renderer/src/store/chat-errors.ts
@@ -1,0 +1,47 @@
+import { isRejected, type Middleware } from '@reduxjs/toolkit';
+import { toast } from 'sonner';
+import { logger } from '../../logger';
+
+const TOAST_BY_REJECTED_ACTION: Record<string, string> = {
+    'chat/loadChats/rejected': 'Failed to load chats',
+    'chat/loadMessages/rejected': 'Failed to load chat messages',
+    'chat/createChat/rejected': 'Failed to create chat',
+    'chat/selectChat/rejected': 'Failed to select chat',
+    'chat/deleteChat/rejected': 'Failed to delete chat',
+    'chat/togglePinned/rejected': 'Failed to update chat pin status',
+    'chat/sendMessage/rejected': 'Failed to send message',
+    'chat/regenerate/rejected': 'Failed to regenerate response',
+    'chat/approveTool/rejected': 'Failed to respond to tool approval',
+    'chat/stopChat/rejected': 'Failed to stop response',
+    'chat/syncMessages/rejected': 'Failed to sync chat messages',
+};
+
+export const logIpcError = (operation: string, error: unknown): void => {
+    logger.error(operation, error);
+};
+
+export const getErrorMessage = (error: unknown): string => {
+    if (error instanceof Error) {
+        return error.message;
+    }
+    if (typeof error === 'string') {
+        return error;
+    }
+    return 'An unexpected error occurred.';
+};
+
+export const chatErrorMiddleware: Middleware = () => (next) => (action) => {
+    const result = next(action);
+    if (!isRejected(action)) {
+        return result;
+    }
+
+    const toastTitle = TOAST_BY_REJECTED_ACTION[action.type];
+    if (!toastTitle) {
+        return result;
+    }
+
+    const description = action.error.message;
+    toast.error(toastTitle, description ? { description } : undefined);
+    return result;
+};

--- a/src/renderer/src/store/chat-runtime-registry.ts
+++ b/src/renderer/src/store/chat-runtime-registry.ts
@@ -1,0 +1,79 @@
+import { Chat } from '@ai-sdk/react';
+import { lastAssistantMessageIsCompleteWithApprovalResponses, type ChatStatus, type UIMessage } from 'ai';
+import { IpcChatTransport } from '@/chat-transport';
+
+interface ChatRuntimeCallbacks {
+    onMessagesChanged: (chatId: string, messages: UIMessage[]) => void;
+    onStatusChanged: (chatId: string, status: ChatStatus, error?: Error) => void;
+    onError: (chatId: string, error: Error) => void;
+}
+
+interface ChatRuntimeEntry {
+    chat: Chat<UIMessage>;
+    callbacks: ChatRuntimeCallbacks;
+    dispose: () => void;
+}
+
+const runtimes = new Map<string, ChatRuntimeEntry>();
+
+export const getExistingChatRuntime = (chatId: string): ChatRuntimeEntry | undefined => runtimes.get(chatId);
+
+export const getChatRuntime = (
+    chatId: string,
+    initialMessages: UIMessage[],
+    callbacks: ChatRuntimeCallbacks,
+): ChatRuntimeEntry => {
+    const existing = runtimes.get(chatId);
+    if (existing) {
+        existing.callbacks = callbacks;
+        return existing;
+    }
+
+    const chat = new Chat<UIMessage>({
+        id: chatId,
+        messages: initialMessages,
+        transport: new IpcChatTransport(),
+        sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
+        onError: (error) => callbacks.onError(chatId, error),
+    });
+
+    const unsubscribeMessages = chat['~registerMessagesCallback'](() => {
+        const entry = runtimes.get(chatId);
+        entry?.callbacks.onMessagesChanged(chatId, chat.messages);
+    });
+    const unsubscribeStatus = chat['~registerStatusCallback'](() => {
+        const entry = runtimes.get(chatId);
+        entry?.callbacks.onStatusChanged(chatId, chat.status, chat.error);
+    });
+    const unsubscribeError = chat['~registerErrorCallback'](() => {
+        const entry = runtimes.get(chatId);
+        if (chat.error) {
+            entry?.callbacks.onError(chatId, chat.error);
+        }
+    });
+
+    const entry: ChatRuntimeEntry = {
+        chat,
+        callbacks,
+        dispose: () => {
+            chat.stop();
+            unsubscribeMessages();
+            unsubscribeStatus();
+            unsubscribeError();
+            runtimes.delete(chatId);
+        },
+    };
+
+    runtimes.set(chatId, entry);
+    return entry;
+};
+
+export const disposeChatRuntime = (chatId: string): void => {
+    runtimes.get(chatId)?.dispose();
+};
+
+export const disposeAllChatRuntimes = (): void => {
+    for (const entry of runtimes.values()) {
+        entry.dispose();
+    }
+};

--- a/src/renderer/src/store/chat-slice.ts
+++ b/src/renderer/src/store/chat-slice.ts
@@ -1,0 +1,495 @@
+import { createAsyncThunk, createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import type { ChatStatus, FileUIPart, UIMessage } from 'ai';
+import type {
+    Chat,
+    ChatMessageSyncAck,
+    CommandDefinition,
+    Persona,
+    ProviderWithModels,
+} from 'core/dto';
+import type { AppDispatch, RootState } from './store';
+import { disposeChatRuntime, getChatRuntime, getExistingChatRuntime } from './chat-runtime-registry';
+import { getErrorMessage, logIpcError } from './chat-errors';
+
+interface ChatSyncState {
+    nextSequence: number;
+    lastAckedSequence: number;
+    pending: number;
+    error?: string;
+}
+
+interface ChatSessionState {
+    messages: UIMessage[];
+    status: ChatStatus;
+    error?: string;
+    sync: ChatSyncState;
+}
+
+interface ChatCatalogState {
+    providers: ProviderWithModels[];
+    personas: Persona[];
+    commands: CommandDefinition[];
+    loaded: boolean;
+}
+
+interface SendChatMessageArgs {
+    chatId: string;
+    text: string;
+    files: FileUIPart[];
+}
+
+interface ToolApprovalResponse {
+    id: string;
+    approved: boolean;
+    reason?: string;
+}
+
+interface ChatState {
+    chats: Chat[];
+    selectedChatId: string | null;
+    historySearchQuery: string | null;
+    conversationSearchQuery: string;
+    currentMatchIndex: number;
+    totalMatches: number;
+    draftsByChatId: Record<string, string>;
+    sessionsByChatId: Record<string, ChatSessionState>;
+    catalog: ChatCatalogState;
+}
+
+const defaultSyncState = (): ChatSyncState => ({
+    nextSequence: 0,
+    lastAckedSequence: 0,
+    pending: 0,
+});
+
+const defaultSessionState = (): ChatSessionState => ({
+    messages: [],
+    status: 'ready',
+    sync: defaultSyncState(),
+});
+
+const initialState: ChatState = {
+    chats: [],
+    selectedChatId: null,
+    historySearchQuery: null,
+    conversationSearchQuery: '',
+    currentMatchIndex: 0,
+    totalMatches: 0,
+    draftsByChatId: {},
+    sessionsByChatId: {},
+    catalog: {
+        providers: [],
+        personas: [],
+        commands: [],
+        loaded: false,
+    },
+};
+
+const syncQueues = new Map<string, Promise<ChatMessageSyncAck>>();
+
+const getOrCreateSession = (state: ChatState, chatId: string): ChatSessionState => {
+    state.sessionsByChatId[chatId] ??= defaultSessionState();
+    return state.sessionsByChatId[chatId];
+};
+
+const extractText = (message: UIMessage | undefined): string | undefined => {
+    if (!message) {
+        return undefined;
+    }
+    return message.parts.find((part): part is { type: 'text'; text: string } => part.type === 'text')?.text;
+};
+
+const applyMessageSummary = (state: ChatState, chatId: string, messages: UIMessage[]): void => {
+    const chat = state.chats.find((item) => item.id === chatId);
+    if (!chat) {
+        return;
+    }
+
+    const lastText = extractText(messages[messages.length - 1]);
+    if (lastText) {
+        chat.lastMessage = lastText.slice(0, 200);
+        chat.lastMessageAt = new Date();
+    }
+
+    if (chat.title === 'New Chat') {
+        const firstUserText = extractText(messages.find((message) => message.role === 'user'));
+        if (firstUserText) {
+            chat.title = firstUserText.slice(0, 50);
+        }
+    }
+};
+
+const runIpc = async <T>(operation: string, call: () => Promise<T>): Promise<T> => {
+    try {
+        return await call();
+    } catch (error) {
+        logIpcError(operation, error);
+        throw error;
+    }
+};
+
+const parsePersonaDirective = (text: string) => {
+    const match = text.match(/^\s*@persona(?:\s*[:=])?\s*(?:"([^"]+)"|'([^']+)'|([^\s]+))\s*/i);
+    if (!match) {
+        return { text };
+    }
+
+    return {
+        text: text.slice(match[0].length).trimStart(),
+    };
+};
+
+const selectedModelMetadata = (chat: Chat) => ({
+    modelId: `${chat.selectedProvider}:${chat.selectedModelId}`,
+    personaId: chat.selectedPersonaId ?? null,
+});
+
+const getRuntimeForDispatch = (chatId: string, state: ChatState, dispatch: AppDispatch) =>
+    getChatRuntime(chatId, state.sessionsByChatId[chatId]?.messages ?? [], {
+        onMessagesChanged: (runtimeChatId, messages) => {
+            dispatch(chatActions.runtimeMessagesChanged({ chatId: runtimeChatId, messages }));
+            void dispatch(syncRuntimeMessages({ chatId: runtimeChatId, messages }));
+        },
+        onStatusChanged: (runtimeChatId, status, error) => {
+            dispatch(chatActions.runtimeStatusChanged({ chatId: runtimeChatId, status, error: error?.message }));
+        },
+        onError: (runtimeChatId, error) => {
+            dispatch(chatActions.runtimeStatusChanged({ chatId: runtimeChatId, status: 'error', error: error.message }));
+        },
+    });
+
+export const loadChatCatalog = createAsyncThunk('chat/loadCatalog', async () => {
+    return runIpc('load chat catalog', async () => {
+        const [providers, personas, commands] = await Promise.all([
+            window.api.modelProvider.getProvidersWithModels(),
+            window.api.persona.getAll(),
+            window.api.command.listAll(),
+        ]);
+        return { providers, personas, commands };
+    });
+});
+
+export const loadChats = createAsyncThunk('chat/loadChats', async (_: void, { dispatch, getState }) => {
+    const query = (getState() as RootState).chat.historySearchQuery;
+    const chats = await runIpc('load chats', () => window.api.chat.getAllChats(query));
+    const selectedChat = chats.find((chat) => chat.selected) ?? chats[0] ?? null;
+    if (selectedChat) {
+        void (dispatch as AppDispatch)(loadMessages(selectedChat.id));
+    }
+    return chats;
+});
+
+export const loadMessages = createAsyncThunk('chat/loadMessages', async (chatId: string, { getState }) => {
+    const existingRuntime = getExistingChatRuntime(chatId);
+    if (existingRuntime && existingRuntime.chat.messages.length > 0) {
+        return {
+            chatId,
+            messages: existingRuntime.chat.messages,
+        };
+    }
+
+    const existingMessages = (getState() as RootState).chat.sessionsByChatId[chatId]?.messages;
+    if (existingRuntime && existingMessages) {
+        return {
+            chatId,
+            messages: existingMessages,
+        };
+    }
+
+    const messages = await runIpc('load chat messages', () => window.api.message.getByChat(chatId));
+    return { chatId, messages };
+});
+
+export const createChat = createAsyncThunk('chat/createChat', async (_: void, { dispatch }) => {
+    await runIpc('create chat', () => window.api.chat.createChat({ title: 'New Chat' }));
+    await (dispatch as AppDispatch)(loadChats()).unwrap();
+});
+
+export const selectChat = createAsyncThunk('chat/selectChat', async (chatId: string, { dispatch }) => {
+    await runIpc('select chat', () => window.api.chat.updateSelectedChat(chatId));
+    dispatch(chatActions.chatSelected(chatId));
+    await (dispatch as AppDispatch)(loadMessages(chatId)).unwrap();
+});
+
+export const deleteChat = createAsyncThunk('chat/deleteChat', async (chatId: string, { dispatch }) => {
+    await runIpc('delete chat', () => window.api.chat.deleteChat(chatId));
+    disposeChatRuntime(chatId);
+    await (dispatch as AppDispatch)(loadChats()).unwrap();
+});
+
+export const togglePinnedChat = createAsyncThunk(
+    'chat/togglePinned',
+    async ({ chatId, pinned }: { chatId: string; pinned: boolean }, { dispatch }) => {
+        await runIpc('toggle chat pin', () => window.api.chat.updatePinnedStatusForChat(chatId, !pinned));
+        await (dispatch as AppDispatch)(loadChats()).unwrap();
+    },
+);
+
+export const updateSelectedModel = createAsyncThunk(
+    'chat/updateSelectedModel',
+    async ({ chatId, providerName, modelId }: { chatId: string; providerName: string; modelId: string }, { dispatch }) => {
+        try {
+            await runIpc('update selected model', () =>
+                window.api.chat.updateSelectedModelForChat(chatId, {
+                    selectedProvider: providerName,
+                    selectedModelId: modelId,
+                }),
+            );
+        } catch (error) {
+            void (dispatch as AppDispatch)(loadChats());
+            throw error;
+        }
+    },
+);
+
+export const updateSelectedPersona = createAsyncThunk(
+    'chat/updateSelectedPersona',
+    async ({ chatId, personaId }: { chatId: string; personaId: string | null }, { dispatch }) => {
+        try {
+            await runIpc('update selected persona', () =>
+                window.api.chat.updateSelectedPersonaForChat(chatId, {
+                    selectedPersonaId: personaId,
+                }),
+            );
+        } catch (error) {
+            void (dispatch as AppDispatch)(loadChats());
+            throw error;
+        }
+    },
+);
+
+export const syncRuntimeMessages = createAsyncThunk(
+    'chat/syncMessages',
+    async ({ chatId, messages }: { chatId: string; messages: UIMessage[] }, { dispatch, getState }) => {
+        const session = (getState() as RootState).chat.sessionsByChatId[chatId];
+        const sequence = (session?.sync.nextSequence ?? 0) + 1;
+        dispatch(chatActions.syncQueued({ chatId, sequence }));
+
+        const previous = syncQueues.get(chatId) ?? Promise.resolve({ chatId, sequence: 0, accepted: true });
+        const queued = previous
+            .catch(() => ({ chatId, sequence: 0, accepted: false }))
+            .then(() =>
+                runIpc('sync chat messages', () =>
+                    window.api.message.syncForChat({
+                        chatId,
+                        sequence,
+                        messages,
+                    }),
+                ),
+            );
+
+        syncQueues.set(chatId, queued);
+        return queued;
+    },
+);
+
+export const sendChatMessage = createAsyncThunk(
+    'chat/sendMessage',
+    async ({ chatId, text, files }: SendChatMessageArgs, { dispatch, getState }) => {
+        const state = (getState() as RootState).chat;
+        const chat = state.chats.find((item) => item.id === chatId);
+        if (!chat?.selectedProvider || !chat.selectedModelId) {
+            throw new Error('Select a model before sending a message.');
+        }
+
+        const metadata = selectedModelMetadata(chat);
+        const { text: cleanedText } = parsePersonaDirective(text);
+        let resolvedText = cleanedText;
+
+        if (cleanedText.trim().startsWith('/')) {
+            const result = await runIpc('execute command', () =>
+                window.api.command.execute({
+                    input: cleanedText,
+                }),
+            );
+            resolvedText = result.resolvedText;
+        }
+
+        const runtime = getRuntimeForDispatch(chatId, state, dispatch as AppDispatch);
+
+        await runtime.chat.sendMessage(
+            {
+                text: resolvedText,
+                files,
+                metadata,
+            },
+            { metadata },
+        );
+    },
+);
+
+export const regenerateChatResponse = createAsyncThunk(
+    'chat/regenerate',
+    async ({ chatId, messageId }: { chatId: string; messageId?: string }, { dispatch, getState }) => {
+        const state = (getState() as RootState).chat;
+        const chat = state.chats.find((item) => item.id === chatId);
+        if (!chat?.selectedProvider || !chat.selectedModelId) {
+            throw new Error('Select a model before regenerating a response.');
+        }
+
+        const runtime = getRuntimeForDispatch(chatId, state, dispatch as AppDispatch);
+
+        await runtime.chat.regenerate({
+            messageId,
+            metadata: selectedModelMetadata(chat),
+        });
+    },
+);
+
+export const approveToolCall = createAsyncThunk(
+    'chat/approveTool',
+    async ({ chatId, response }: { chatId: string; response: ToolApprovalResponse }, { dispatch, getState }) => {
+        const state = (getState() as RootState).chat;
+        const runtime = getRuntimeForDispatch(chatId, state, dispatch as AppDispatch);
+        await runtime.chat.addToolApprovalResponse(response);
+    },
+);
+
+export const stopChatResponse = createAsyncThunk('chat/stopChat', async (chatId: string, { dispatch, getState }) => {
+    const state = (getState() as RootState).chat;
+    const runtime = getRuntimeForDispatch(chatId, state, dispatch as AppDispatch);
+    runtime.chat.stop();
+});
+
+export const chatSlice = createSlice({
+    name: 'chat',
+    initialState,
+    reducers: {
+        historySearchChanged(state, action: PayloadAction<string | null>) {
+            state.historySearchQuery = action.payload;
+        },
+        chatSelected(state, action: PayloadAction<string>) {
+            state.selectedChatId = action.payload;
+            for (const chat of state.chats) {
+                chat.selected = chat.id === action.payload;
+            }
+            getOrCreateSession(state, action.payload);
+        },
+        conversationSearchChanged(state, action: PayloadAction<string>) {
+            state.conversationSearchQuery = action.payload;
+            if (!action.payload) {
+                state.currentMatchIndex = 0;
+                state.totalMatches = 0;
+            }
+        },
+        matchesFound(state, action: PayloadAction<number>) {
+            state.totalMatches = action.payload;
+            if (action.payload > 0) {
+                if (state.currentMatchIndex === 0) {
+                    state.currentMatchIndex = 1;
+                } else if (state.currentMatchIndex > action.payload) {
+                    state.currentMatchIndex = action.payload;
+                }
+            } else {
+                state.currentMatchIndex = 0;
+            }
+        },
+        nextMatch(state) {
+            if (state.totalMatches > 0) {
+                state.currentMatchIndex =
+                    state.currentMatchIndex < state.totalMatches ? state.currentMatchIndex + 1 : 1;
+            }
+        },
+        previousMatch(state) {
+            if (state.totalMatches > 0) {
+                state.currentMatchIndex =
+                    state.currentMatchIndex > 1 ? state.currentMatchIndex - 1 : state.totalMatches;
+            }
+        },
+        clearConversationSearch(state) {
+            state.conversationSearchQuery = '';
+            state.currentMatchIndex = 0;
+            state.totalMatches = 0;
+        },
+        draftChanged(state, action: PayloadAction<{ chatId: string; draft: string }>) {
+            state.draftsByChatId[action.payload.chatId] = action.payload.draft;
+        },
+        runtimeMessagesChanged(state, action: PayloadAction<{ chatId: string; messages: UIMessage[] }>) {
+            const session = getOrCreateSession(state, action.payload.chatId);
+            session.messages = action.payload.messages;
+            applyMessageSummary(state, action.payload.chatId, action.payload.messages);
+        },
+        runtimeStatusChanged(
+            state,
+            action: PayloadAction<{ chatId: string; status: ChatStatus; error?: string }>,
+        ) {
+            const session = getOrCreateSession(state, action.payload.chatId);
+            session.status = action.payload.status;
+            session.error = action.payload.error;
+        },
+        syncQueued(state, action: PayloadAction<{ chatId: string; sequence: number }>) {
+            const sync = getOrCreateSession(state, action.payload.chatId).sync;
+            sync.nextSequence = action.payload.sequence;
+            sync.pending += 1;
+            sync.error = undefined;
+        },
+    },
+    extraReducers: (builder) => {
+        builder
+            .addCase(loadChatCatalog.fulfilled, (state, action) => {
+                state.catalog = {
+                    providers: action.payload.providers,
+                    personas: action.payload.personas,
+                    commands: action.payload.commands,
+                    loaded: true,
+                };
+            })
+            .addCase(loadChats.fulfilled, (state, action) => {
+                state.chats = action.payload;
+                state.selectedChatId = action.payload.find((chat) => chat.selected)?.id ?? action.payload[0]?.id ?? null;
+                if (state.selectedChatId) {
+                    getOrCreateSession(state, state.selectedChatId);
+                }
+            })
+            .addCase(loadChats.rejected, (state) => {
+                state.chats = [];
+                state.selectedChatId = null;
+            })
+            .addCase(loadMessages.fulfilled, (state, action) => {
+                const session = getOrCreateSession(state, action.payload.chatId);
+                session.messages = action.payload.messages;
+                session.error = undefined;
+            })
+            .addCase(loadMessages.rejected, (state, action) => {
+                const chatId = action.meta.arg;
+                getOrCreateSession(state, chatId).error = getErrorMessage(action.error.message);
+            })
+            .addCase(updateSelectedModel.pending, (state, action) => {
+                const chat = state.chats.find((item) => item.id === action.meta.arg.chatId);
+                if (chat) {
+                    chat.selectedProvider = action.meta.arg.providerName;
+                    chat.selectedModelId = action.meta.arg.modelId;
+                }
+            })
+            .addCase(updateSelectedPersona.pending, (state, action) => {
+                const chat = state.chats.find((item) => item.id === action.meta.arg.chatId);
+                if (chat) {
+                    chat.selectedPersonaId = action.meta.arg.personaId;
+                }
+            })
+            .addCase(syncRuntimeMessages.fulfilled, (state, action) => {
+                const sync = getOrCreateSession(state, action.payload.chatId).sync;
+                sync.pending = Math.max(0, sync.pending - 1);
+                if (action.payload.accepted) {
+                    sync.lastAckedSequence = Math.max(sync.lastAckedSequence, action.payload.sequence);
+                }
+            })
+            .addCase(syncRuntimeMessages.rejected, (state, action) => {
+                const chatId = action.meta.arg.chatId;
+                const sync = getOrCreateSession(state, chatId).sync;
+                sync.pending = Math.max(0, sync.pending - 1);
+                sync.error = getErrorMessage(action.error.message);
+            });
+    },
+});
+
+export const chatActions = chatSlice.actions;
+export const chatReducer = chatSlice.reducer;
+
+export const selectChats = (state: RootState) => state.chat.chats;
+export const selectSelectedChat = (state: RootState) =>
+    state.chat.chats.find((chat) => chat.id === state.chat.selectedChatId) ?? null;
+export const selectSelectedMessages = (state: RootState) =>
+    state.chat.selectedChatId ? state.chat.sessionsByChatId[state.chat.selectedChatId]?.messages ?? [] : [];
+export const selectSelectedStatus = (state: RootState) =>
+    state.chat.selectedChatId ? state.chat.sessionsByChatId[state.chat.selectedChatId]?.status ?? 'ready' : 'ready';

--- a/src/renderer/src/store/hooks.ts
+++ b/src/renderer/src/store/hooks.ts
@@ -1,0 +1,5 @@
+import { useDispatch, useSelector, type TypedUseSelectorHook } from 'react-redux';
+import type { AppDispatch, RootState } from './store';
+
+export const useAppDispatch = () => useDispatch<AppDispatch>();
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/renderer/src/store/provider.tsx
+++ b/src/renderer/src/store/provider.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import { Provider } from 'react-redux';
+import type { ReactNode } from 'react';
+import { store } from './store';
+
+export function StoreProvider({ children }: { children: ReactNode }) {
+    return <Provider store={store}>{children}</Provider>;
+}

--- a/src/renderer/src/store/store.ts
+++ b/src/renderer/src/store/store.ts
@@ -1,0 +1,16 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { chatErrorMiddleware } from './chat-errors';
+import { chatReducer } from './chat-slice';
+
+export const store = configureStore({
+    reducer: {
+        chat: chatReducer,
+    },
+    middleware: (getDefaultMiddleware) =>
+        getDefaultMiddleware({
+            serializableCheck: false,
+        }).concat(chatErrorMiddleware),
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;


### PR DESCRIPTION
## Summary

- Move chat page state and IPC calls into Redux Toolkit thunks/selectors.
- Add a module-level AI SDK `Chat` runtime registry so streams survive route changes and multiple chats can run in parallel.
- Add validated `message:syncForChat` IPC and DB storage for serialized `UIMessage` snapshots with monotonic per-chat sync versions.
- Remove direct message persistence from `StreamingChatController` and update tests/docs/agent guidance.

## Validation

- `npm run lint`
- `cd src/renderer && npm run lint`
- `npm run test`
- `cd src/renderer && npm run test`
- `npm run db:check`
- `cd src/renderer && npm run build`
- `npm run package`

Note: `npm run package` required elevated execution because Next/Turbopack needs to bind an internal worker port in this sandbox.