### PR TITLE
Keep 404 pages inside app shell

### DIFF
--- a/src/renderer/src/app/(main)/layout.tsx
+++ b/src/renderer/src/app/(main)/layout.tsx
@@ -1,31 +1,12 @@
 'use client';
 
-import { AppSidebar } from '@/components/app-sidebar';
-import { SiteHeader } from '@/components/site-header';
-import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
+import { AppShell } from '@/components/app-shell';
 import React from 'react';
-import { Toaster } from 'sonner';
 
 export default function MainLayout({
     children,
 }: Readonly<{
     children: React.ReactNode;
 }>) {
-    return (
-        <SidebarProvider
-            style={
-                {
-                    '--sidebar-width-icon': '3rem',
-                    '--header-height': 'calc(var(--spacing) * 14)',
-                } as React.CSSProperties
-            }
-        >
-            <AppSidebar />
-            <SidebarInset className="h-[calc(100svh-var(--header-height))] max-h-[calc(100svh-var(--header-height))] overflow-hidden">
-                <SiteHeader />
-                <div className="@container/main flex flex-1 flex-col min-h-0 w-full overflow-hidden">{children}</div>
-            </SidebarInset>
-            <Toaster position="top-center" />
-        </SidebarProvider>
-    );
+    return <AppShell>{children}</AppShell>;
 }

--- a/src/renderer/src/app/__tests__/not-found.test.tsx
+++ b/src/renderer/src/app/__tests__/not-found.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import type { ComponentProps, ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import NotFoundPage from '../not-found';
+
+const { appShellMock } = vi.hoisted(() => ({
+    appShellMock: vi.fn(({ children }: { children: ReactNode }) => <div data-testid="app-shell">{children}</div>),
+}));
+
+vi.mock('@/components/app-shell', () => ({
+    AppShell: appShellMock,
+}));
+
+vi.mock('next/link', () => ({
+    default: ({ children, href, ...props }: ComponentProps<'a'> & { href: string; prefetch?: boolean }) => {
+        const { prefetch, ...anchorProps } = props;
+        void prefetch;
+
+        return (
+            <a href={href} {...anchorProps}>
+                {children}
+            </a>
+        );
+    },
+}));
+
+describe('NotFoundPage', () => {
+    it('renders the 404 content inside the shared app shell', () => {
+        render(<NotFoundPage />);
+
+        expect(appShellMock).toHaveBeenCalledTimes(1);
+        expect(screen.getByTestId('app-shell')).toBeInTheDocument();
+        expect(screen.getByText('404')).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: /page not found/i })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /go to chat/i })).toHaveAttribute('href', '/chat');
+    });
+});

--- a/src/renderer/src/app/not-found.tsx
+++ b/src/renderer/src/app/not-found.tsx
@@ -1,0 +1,25 @@
+import { AppShell } from '@/components/app-shell';
+import { Button } from '@/components/ui/button';
+import Link from 'next/link';
+
+// Keep unmatched routes inside the main application frame instead of replacing it.
+export default function NotFoundPage() {
+    return (
+        <AppShell>
+            <main className="flex min-h-0 flex-1 items-center justify-center p-4 sm:p-6">
+                <section className="flex w-full max-w-xl flex-col items-center rounded-lg border bg-background px-6 py-10 text-center shadow-xs sm:px-10">
+                    <p className="text-sm font-medium tracking-[0.2em] text-muted-foreground uppercase">404</p>
+                    <h1 className="mt-4 text-3xl font-semibold tracking-tight text-balance sm:text-4xl">
+                        Page not found
+                    </h1>
+                    <p className="mt-3 max-w-md text-sm leading-6 text-muted-foreground sm:text-base">
+                        The page you requested does not exist or is no longer available.
+                    </p>
+                    <Button asChild className="mt-6">
+                        <Link href="/chat">Go to chat</Link>
+                    </Button>
+                </section>
+            </main>
+        </AppShell>
+    );
+}

--- a/src/renderer/src/components/app-shell.tsx
+++ b/src/renderer/src/components/app-shell.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { AppSidebar } from '@/components/app-sidebar';
+import { SiteHeader } from '@/components/site-header';
+import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
+import type React from 'react';
+import { Toaster } from 'sonner';
+
+// Reuse the primary app chrome so route states like 404 stay inside the normal shell.
+export function AppShell({
+    children,
+}: Readonly<{
+    children: React.ReactNode;
+}>) {
+    return (
+        <SidebarProvider
+            style={
+                {
+                    '--sidebar-width-icon': '3rem',
+                    '--header-height': 'calc(var(--spacing) * 14)',
+                } as React.CSSProperties
+            }
+        >
+            <AppSidebar />
+            <SidebarInset className="h-[calc(100svh-var(--header-height))] max-h-[calc(100svh-var(--header-height))] overflow-hidden">
+                <SiteHeader />
+                <div className="@container/main flex min-h-0 w-full flex-1 flex-col overflow-hidden">{children}</div>
+            </SidebarInset>
+            <Toaster position="top-center" />
+        </SidebarProvider>
+    );
+}


### PR DESCRIPTION
## Summary
This keeps renderer 404 pages inside the normal Cosmo Studio chrome instead of replacing the full screen.

## What changed
- extracted the shared sidebar/header/toaster chrome into `AppShell`
- updated the `(main)` layout to render through `AppShell`
- added a root `app/not-found.tsx` that renders the 404 state inside the shared shell
- added a renderer test to verify the root 404 renders through `AppShell`

## Root cause
Unmatched routes were falling back to the root App Router 404 path, which was not wrapped by the `(main)` route-group layout. That caused the sidebar and header to disappear whenever a 404 rendered.

## Impact
- users keep the standard sidebar/header context on 404
- navigation back into chat is available directly from the 404 state
- future shell-level route states can reuse the shared `AppShell`

## Validation
- `src/renderer` eslint: passed
- `src/renderer` vitest: passed (`20` files, `45` tests)

## Known unrelated repo-level issues observed during verification
- root `npm run lint` currently fails on generated `src/preload/api/*` and `src/preload/http-api/*` files
- `npm run build:http` failed in the temporary worktree because Next/Turbopack rejects an out-of-root `node_modules` symlink